### PR TITLE
Add unit tests for 'operation'

### DIFF
--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -613,6 +613,9 @@ static int stackdriver_format(struct flb_config *config,
         /* Extract operation */
         operation_id = flb_sds_create("");
         operation_producer = flb_sds_create("");
+        operation_first = false;
+        operation_last = false;
+        operation_extra_size = 0;
         operation_extracted = extract_operation(&operation_id, &operation_producer,
                               &operation_first, &operation_last, obj, &operation_extra_size);
         

--- a/plugins/out_stackdriver/stackdriver_operation.c
+++ b/plugins/out_stackdriver/stackdriver_operation.c
@@ -79,10 +79,7 @@ bool extract_operation(flb_sds_t *operation_id, flb_sds_t *operation_producer,
                 msgpack_object_kv* tmp_p = sub_field.via.map.ptr;
                 msgpack_object_kv* const tmp_pend = sub_field.via.map.ptr + sub_field.via.map.size;
 
-                /* Validate the subfields 
-                 * If there's an extra subfield, remain it in the jsonPayload
-                 * If one of the subfield is invalid, set it to default
-                 */
+                /* Validate the subfields of operation */
                 for (; tmp_p < tmp_pend; ++tmp_p) {
                     if (strncmp("id", tmp_p->key.via.str.ptr, tmp_p->key.via.str.size) == 0) {
                         if(tmp_p->val.type != MSGPACK_OBJECT_STR) {

--- a/tests/runtime/data/stackdriver/stackdriver_test_operation.h
+++ b/tests/runtime/data/stackdriver/stackdriver_test_operation.h
@@ -24,18 +24,6 @@
     "\"logging.googleapis.com/operation\": \"some string\""		\
 	"}]"
 
-#define EMPTY_SUBFIELDS	"["		\
-	"1591111124,"			\
-	"{"				\
-        "\"logging.googleapis.com/operation\": "		\
-        "{"            \
-            "\"id\": \"\","          \
-            "\"producer\": \"\","      \
-            "\"first\": false,"      \
-            "\"last\": false"       \
-        "}"     \
-	"}]"
-
 #define PARTIAL_SUBFIELDS	"["		\
 	"1591111124,"			\
 	"{"				\

--- a/tests/runtime/data/stackdriver/stackdriver_test_operation.h
+++ b/tests/runtime/data/stackdriver/stackdriver_test_operation.h
@@ -1,0 +1,74 @@
+#define OPERATION_COMMON_CASE	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/operation\": "		\
+        "{"            \
+            "\"id\": \"test_id\","          \
+            "\"producer\": \"test_producer\","      \
+            "\"first\": true,"      \
+            "\"last\": true"       \
+        "}"     \
+	"}]"
+
+#define EMPTY_OPERATION	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/operation\": "		\
+        "{"            \
+        "}"     \
+	"}]"
+
+#define OPERATION_IN_STRING "["		\
+	"1591111124,"			\
+	"{"				\
+    "\"logging.googleapis.com/operation\": \"some string\""		\
+	"}]"
+
+#define EMPTY_SUBFIELDS	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/operation\": "		\
+        "{"            \
+            "\"id\": \"\","          \
+            "\"producer\": \"\","      \
+            "\"first\": false,"      \
+            "\"last\": false"       \
+        "}"     \
+	"}]"
+
+#define PARTIAL_SUBFIELDS	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/operation\": "		\
+        "{"            \
+            "\"first\": false,"      \
+            "\"last\": false"       \
+        "}"     \
+	"}]"
+
+#define SUBFIELDS_IN_INCORRECT_TYPE	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/operation\": "		\
+        "{"            \
+            "\"id\": 123,"          \
+            "\"producer\": true,"      \
+            "\"first\": \"some string\","      \
+            "\"last\": 123"       \
+        "}"     \
+	"}]"
+
+#define EXTRA_SUBFIELDS_EXISTED	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/operation\": "		\
+        "{"            \
+            "\"id\": \"test_id\","          \
+            "\"producer\": \"test_producer\","      \
+            "\"first\": true,"      \
+            "\"last\": true,"       \
+            "\"extra_key1\": \"extra_val1\","          \
+            "\"extra_key2\": 123,"      \
+            "\"extra_key3\": true"          \
+        "}"     \
+	"}]"

--- a/tests/runtime/out_stackdriver.c
+++ b/tests/runtime/out_stackdriver.c
@@ -30,6 +30,7 @@
 
 /* JSON payload example */
 #include "data/stackdriver/json.h"
+#include "data/stackdriver/stackdriver_test_operation.h"
 
 /*
  * Fluent Bit Stackdriver plugin, always set as payload a JSON strings contained in a
@@ -76,8 +77,7 @@ static int mp_kv_cmp(char *json_data, size_t json_len, char *key_accessor, char 
         flb_error("invalid record accessor key, aborting test");
         goto out;
     }
-
-    /* Process map using the record_accessor */
+    
     rval = flb_ra_get_value_object(ra, map);
     TEST_CHECK(rval != NULL);
     msgpack_unpacked_destroy(&result);
@@ -89,6 +89,183 @@ static int mp_kv_cmp(char *json_data, size_t json_len, char *key_accessor, char 
     TEST_CHECK(rval->type == FLB_RA_STRING);
     if (strcmp(rval->val.string, val) == 0) {
         ret = FLB_TRUE;
+    }
+
+ out:
+    if (rval) {
+        flb_ra_key_value_destroy(rval);
+    }
+    if (ra) {
+        flb_ra_destroy(ra);
+    }
+    if (mp_buf) {
+        flb_free(mp_buf);
+    }
+    return ret;
+}
+
+static int mp_kv_cmp_integer(char *json_data, size_t json_len, char *key_accessor, int64_t val)
+{
+    int ret;
+    int type;
+    char *mp_buf = NULL;
+    size_t mp_size;
+    size_t off = 0;
+    msgpack_object map;
+    msgpack_unpacked result;
+    struct flb_ra_value *rval = NULL;
+    struct flb_record_accessor *ra = NULL;
+
+    /* Convert JSON to msgpack */
+    ret = flb_pack_json((const char *) json_data, json_len, &mp_buf, &mp_size,
+                        &type);
+    TEST_CHECK(ret != -1);
+
+    /* Set return status */
+    ret = FLB_FALSE;
+
+    /* Unpack msgpack and reference the main 'map' */
+    msgpack_unpacked_init(&result);
+    ret = msgpack_unpack_next(&result, mp_buf, mp_size, &off);
+    TEST_CHECK(ret == MSGPACK_UNPACK_SUCCESS);
+    map = result.data;
+
+    /* Create a record_accessor context */
+    ra = flb_ra_create(key_accessor, FLB_TRUE);
+    if (!ra) {
+        flb_error("invalid record accessor key, aborting test");
+        goto out;
+    }
+    
+    rval = flb_ra_get_value_object(ra, map);
+    TEST_CHECK(rval != NULL);
+    msgpack_unpacked_destroy(&result);
+    if (!rval) {
+        goto out;
+    }
+
+    TEST_CHECK(rval->type == FLB_RA_INT);
+    if (rval->val.i64 == val) {
+        ret = FLB_TRUE;
+    }
+    else {
+        ret = FLB_FALSE;
+    }
+
+ out:
+    if (rval) {
+        flb_ra_key_value_destroy(rval);
+    }
+    if (ra) {
+        flb_ra_destroy(ra);
+    }
+    if (mp_buf) {
+        flb_free(mp_buf);
+    }
+    return ret;
+}
+
+static int mp_kv_cmp_boolean(char *json_data, size_t json_len, char *key_accessor, bool val)
+{
+    int ret;
+    int type;
+    char *mp_buf = NULL;
+    size_t mp_size;
+    size_t off = 0;
+    msgpack_object map;
+    msgpack_unpacked result;
+    struct flb_ra_value *rval = NULL;
+    struct flb_record_accessor *ra = NULL;
+
+    /* Convert JSON to msgpack */
+    ret = flb_pack_json((const char *) json_data, json_len, &mp_buf, &mp_size,
+                        &type);
+    TEST_CHECK(ret != -1);
+
+    /* Set return status */
+    ret = FLB_FALSE;
+
+    /* Unpack msgpack and reference the main 'map' */
+    msgpack_unpacked_init(&result);
+    ret = msgpack_unpack_next(&result, mp_buf, mp_size, &off);
+    TEST_CHECK(ret == MSGPACK_UNPACK_SUCCESS);
+    map = result.data;
+
+    /* Create a record_accessor context */
+    ra = flb_ra_create(key_accessor, FLB_TRUE);
+    if (!ra) {
+        flb_error("invalid record accessor key, aborting test");
+        goto out;
+    }
+    
+    rval = flb_ra_get_value_object(ra, map);
+    TEST_CHECK(rval != NULL);
+    msgpack_unpacked_destroy(&result);
+    if (!rval) {
+        goto out;
+    }
+
+    TEST_CHECK(rval->type == FLB_RA_BOOL);
+    if (rval->val.boolean == val) {
+        ret = FLB_TRUE;
+    }
+    else {
+        ret = FLB_FALSE;
+    }
+
+ out:
+    if (rval) {
+        flb_ra_key_value_destroy(rval);
+    }
+    if (ra) {
+        flb_ra_destroy(ra);
+    }
+    if (mp_buf) {
+        flb_free(mp_buf);
+    }
+    return ret;
+}
+
+static int mp_kv_exists(char *json_data, size_t json_len, char *key_accessor)
+{
+    int ret;
+    int type;
+    char *mp_buf = NULL;
+    size_t mp_size;
+    size_t off = 0;
+    msgpack_object map;
+    msgpack_unpacked result;
+    struct flb_ra_value *rval = NULL;
+    struct flb_record_accessor *ra = NULL;
+
+    /* Convert JSON to msgpack */
+    ret = flb_pack_json((const char *) json_data, json_len, &mp_buf, &mp_size,
+                        &type);
+    TEST_CHECK(ret != -1);
+
+    /* Set return status */
+    ret = FLB_FALSE;
+
+    /* Unpack msgpack and reference the main 'map' */
+    msgpack_unpacked_init(&result);
+    ret = msgpack_unpack_next(&result, mp_buf, mp_size, &off);
+    TEST_CHECK(ret == MSGPACK_UNPACK_SUCCESS);
+    map = result.data;
+
+    /* Create a record_accessor context */
+    ra = flb_ra_create(key_accessor, FLB_TRUE);
+    if (!ra) {
+        flb_error("invalid record accessor key, aborting test");
+        goto out;
+    }
+    
+    rval = flb_ra_get_value_object(ra, map);
+    msgpack_unpacked_destroy(&result);
+    if (rval) {
+        ret = FLB_TRUE;
+    }
+    else {
+        ret = FLB_FALSE;
     }
 
  out:
@@ -138,6 +315,203 @@ static void cb_check_gce_instance(void *ctx, int ffd,
     /* instance_id */
     ret = mp_kv_cmp(res_data, res_size,
                     "$resource['labels']['instance_id']", "333222111");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_operation_common_case(void *ctx, int ffd,
+                                           int res_ret, void *res_data, size_t res_size,
+                                           void *data)
+{
+    int ret;
+
+    /* operation_id */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['operation']['id']", "test_id");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* operation_producer */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['operation']['producer']", "test_producer");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* operation_first */
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['operation']['first']", true);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* operation_last */
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['operation']['last']", true);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* check `operation` has been removed from jsonPayload */
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/operation']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_empty_operation(void *ctx, int ffd,
+                                           int res_ret, void *res_data, size_t res_size,
+                                           void *data)
+{
+    int ret;
+
+    /* operation_id */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['operation']['id']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* operation_producer */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['operation']['producer']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* operation_first */
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['operation']['first']", false);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* operation_last */
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['operation']['last']", false);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* check `operation` has been removed from jsonPayload */
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/operation']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_operation_in_string(void *ctx, int ffd,
+                                           int res_ret, void *res_data, size_t res_size,
+                                           void *data)
+{
+    int ret;
+
+    /* 'operation' is not a map, won't be extracted from jsonPayload */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/operation']", "some string");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['operation']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_operation_empty_subfields(void *ctx, int ffd,
+                                           int res_ret, void *res_data, size_t res_size,
+                                           void *data)
+{
+    int ret;
+
+    /* operation_id */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['operation']['id']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* operation_producer */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['operation']['producer']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* operation_first */
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['operation']['first']", false);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* operation_last */
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['operation']['last']", false);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* check `operation` has been removed from jsonPayload */
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/operation']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
+}
+
+/* TODO: merge partial and empty? */
+static void cb_check_operation_partial_subfields(void *ctx, int ffd,
+                                           int res_ret, void *res_data, size_t res_size,
+                                           void *data)
+{
+    int ret;
+
+    /* operation_id */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['operation']['id']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* operation_producer */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['operation']['producer']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* operation_first */
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['operation']['first']", false);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* operation_last */
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['operation']['last']", false);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* check `operation` has been removed from jsonPayload */
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/operation']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_operation_incorrect_type_subfields(void *ctx, int ffd,
+                                           int res_ret, void *res_data, size_t res_size,
+                                           void *data)
+{
+    int ret;
+
+    /* operation_id */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['operation']['id']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* operation_producer */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['operation']['producer']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* operation_first */
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['operation']['first']", false);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* operation_last */
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['operation']['last']", false);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* check `operation` has been removed from jsonPayload */
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/operation']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_operation_extra_subfields(void *ctx, int ffd,
+                                           int res_ret, void *res_data, size_t res_size,
+                                           void *data)
+{
+    int ret;
+
+    /* operation_id */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['operation']['id']", "test_id");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* operation_producer */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['operation']['producer']", "test_producer");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* operation_first */
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['operation']['first']", true);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* operation_last */
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['operation']['last']", true);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* Preserve extra subfields inside jsonPayload */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/operation']['extra_key1']", "extra_val1");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/operation']['extra_key2']", 123);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/operation']['extra_key3']", true);
     TEST_CHECK(ret == FLB_TRUE);
 
     flb_sds_destroy(res_data);
@@ -224,9 +598,296 @@ void flb_test_resource_gce_instance()
     flb_destroy(ctx);
 }
 
+void flb_test_operation_common()
+{
+    int ret;
+    int size = sizeof(OPERATION_COMMON_CASE) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_operation_common_case,
+                              NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) OPERATION_COMMON_CASE, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_empty_operation()
+{
+    int ret;
+    int size = sizeof(EMPTY_OPERATION) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_empty_operation,
+                              NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) EMPTY_OPERATION, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_operation_in_string()
+{
+    int ret;
+    int size = sizeof(OPERATION_IN_STRING) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_operation_in_string,
+                              NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) OPERATION_IN_STRING, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_operation_empty_subfields()
+{
+    int ret;
+    int size = sizeof(EMPTY_SUBFIELDS) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_operation_empty_subfields,
+                              NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) EMPTY_SUBFIELDS, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_operation_partial_subfields()
+{
+    int ret;
+    int size = sizeof(PARTIAL_SUBFIELDS) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_operation_partial_subfields,
+                              NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) PARTIAL_SUBFIELDS, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_operation_incorrect_type_subfields()
+{
+    int ret;
+    int size = sizeof(SUBFIELDS_IN_INCORRECT_TYPE) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_operation_incorrect_type_subfields,
+                              NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) SUBFIELDS_IN_INCORRECT_TYPE, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_operation_extra_subfields()
+{
+    int ret;
+    int size = sizeof(EXTRA_SUBFIELDS_EXISTED) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_operation_extra_subfields,
+                              NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) EXTRA_SUBFIELDS_EXISTED, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
 /* Test list */
 TEST_LIST = {
     {"resource_global"      , flb_test_resource_global },
     {"resource_gce_instance", flb_test_resource_gce_instance },
+    {"operation_common_case", flb_test_operation_common},
+    {"empty_operation", flb_test_empty_operation},
+    {"operation_not_a_map", flb_test_operation_in_string},
+    {"operation_empty_subfields", flb_test_operation_empty_subfields},
+    {"operation_partial_subfields", flb_test_operation_partial_subfields},
+    {"operation_subfields_in_incorrect_type", flb_test_operation_incorrect_type_subfields},
+    {"operation_extra_subfields_exist", flb_test_operation_extra_subfields},
     {NULL, NULL}
 };

--- a/tests/runtime/out_stackdriver.c
+++ b/tests/runtime/out_stackdriver.c
@@ -394,36 +394,7 @@ static void cb_check_operation_in_string(void *ctx, int ffd,
     flb_sds_destroy(res_data);
 }
 
-static void cb_check_operation_empty_subfields(void *ctx, int ffd,
-                                           int res_ret, void *res_data, size_t res_size,
-                                           void *data)
-{
-    int ret;
 
-    /* operation_id */
-    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['operation']['id']", "");
-    TEST_CHECK(ret == FLB_TRUE);
-
-    /* operation_producer */
-    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['operation']['producer']", "");
-    TEST_CHECK(ret == FLB_TRUE);
-
-    /* operation_first */
-    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['operation']['first']", false);
-    TEST_CHECK(ret == FLB_TRUE);
-
-    /* operation_last */
-    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['operation']['last']", false);
-    TEST_CHECK(ret == FLB_TRUE);
-
-    /* check `operation` has been removed from jsonPayload */
-    ret = mp_kv_exists(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/operation']");
-    TEST_CHECK(ret == FLB_FALSE);
-
-    flb_sds_destroy(res_data);
-}
-
-/* TODO: merge partial and empty? */
 static void cb_check_operation_partial_subfields(void *ctx, int ffd,
                                            int res_ret, void *res_data, size_t res_size,
                                            void *data)
@@ -718,46 +689,6 @@ void flb_test_operation_in_string()
     flb_destroy(ctx);
 }
 
-void flb_test_operation_empty_subfields()
-{
-    int ret;
-    int size = sizeof(EMPTY_SUBFIELDS) - 1;
-    flb_ctx_t *ctx;
-    int in_ffd;
-    int out_ffd;
-
-    /* Create context, flush every second (some checks omitted here) */
-    ctx = flb_create();
-    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
-
-    /* Lib input mode */
-    in_ffd = flb_input(ctx, (char *) "lib", NULL);
-    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
-
-    /* Stackdriver output */
-    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
-    flb_output_set(ctx, out_ffd,
-                   "match", "test",
-                   "resource", "gce_instance",
-                   NULL);
-
-    /* Enable test mode */
-    ret = flb_output_set_test(ctx, out_ffd, "formatter",
-                              cb_check_operation_empty_subfields,
-                              NULL);
-
-    /* Start */
-    ret = flb_start(ctx);
-    TEST_CHECK(ret == 0);
-
-    /* Ingest data sample */
-    flb_lib_push(ctx, in_ffd, (char *) EMPTY_SUBFIELDS, size);
-
-    sleep(2);
-    flb_stop(ctx);
-    flb_destroy(ctx);
-}
-
 void flb_test_operation_partial_subfields()
 {
     int ret;
@@ -885,7 +816,6 @@ TEST_LIST = {
     {"operation_common_case", flb_test_operation_common},
     {"empty_operation", flb_test_empty_operation},
     {"operation_not_a_map", flb_test_operation_in_string},
-    {"operation_empty_subfields", flb_test_operation_empty_subfields},
     {"operation_partial_subfields", flb_test_operation_partial_subfields},
     {"operation_subfields_in_incorrect_type", flb_test_operation_incorrect_type_subfields},
     {"operation_extra_subfields_exist", flb_test_operation_extra_subfields},


### PR DESCRIPTION
Add some unit tests for 'operation'
Test cases are designed here: https://docs.google.com/document/d/1UiMRZPnT0xntYL8lYFgy0UjFPcoRX0oOCbf3MQVwJRw/edit#

Currently, I preserve those extra subfields in the jsonPayload. Will update after Morgan replies to this issue.