### PR TITLE
Validate insertId

### DIFF
--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -1204,6 +1204,9 @@ static int stackdriver_format(struct flb_config *config,
         else if (in_status == INSERTID_NOT_EXISTED) {
             insert_id_extracted = FLB_FALSE;
         }
+        else {
+            continue;
+        }
 
         /* Extract operation */
         operation_id = flb_sds_create("");

--- a/tests/runtime/data/stackdriver/stackdriver_test_insert_id.h
+++ b/tests/runtime/data/stackdriver/stackdriver_test_insert_id.h
@@ -22,16 +22,5 @@
         "\"logging.googleapis.com/insertId\": "		\
         "{"           \       
         "}"     \
-	"}]"
+	"}]"			
 
-#define INSERTID_MULTI_ENTRIES	"["		\
-	"1591111124,"			\
-	"{"				\
-        "\"logging.googleapis.com/insertId\": \"test_insertId\" "		\
-	"},"			\
-	"{"				\
-        "\"logging.googleapis.com/insertId\": 123 "		\
-	"},"			\
-	"{"				\
-        "\"logging.googleapis.com/insertId\": \"\" "		\
-	"}]"

--- a/tests/runtime/data/stackdriver/stackdriver_test_insert_id.h
+++ b/tests/runtime/data/stackdriver/stackdriver_test_insert_id.h
@@ -23,3 +23,15 @@
         "{"           \       
         "}"     \
 	"}]"
+
+#define INSERTID_MULTI_ENTRIES	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/insertId\": \"test_insertId\" "		\
+	"},"			\
+	"{"				\
+        "\"logging.googleapis.com/insertId\": 123 "		\
+	"},"			\
+	"{"				\
+        "\"logging.googleapis.com/insertId\": \"\" "		\
+	"}]"

--- a/tests/runtime/out_stackdriver.c
+++ b/tests/runtime/out_stackdriver.c
@@ -656,10 +656,6 @@ static void cb_check_insert_id_incorrect_type(void *ctx, int ffd,
     flb_sds_destroy(res_data);
 }
 
-static void cb_check_insert_id_multi_entries(void *ctx, int ffd,
-                                             int res_ret, void *res_data, size_t res_size,
-                                             void *data)
-
 static void cb_check_source_location_common_case(void *ctx, int ffd,
                                                  int res_ret, void *res_data, size_t res_size,
                                                  void *data)

--- a/tests/runtime/out_stackdriver.c
+++ b/tests/runtime/out_stackdriver.c
@@ -656,6 +656,27 @@ static void cb_check_insert_id_incorrect_type(void *ctx, int ffd,
     flb_sds_destroy(res_data);
 }
 
+static void cb_check_insert_id_multi_entries(void *ctx, int ffd,
+                                             int res_ret, void *res_data, size_t res_size,
+                                             void *data)
+{
+    int ret;
+
+    /* valid insertId in the entries */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['insertId']", "test_insertId");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* valid insertId has been removed from jsonPayload */
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/insertId']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    /* invalid entries have been removed */
+    ret = mp_kv_exists(res_data, res_size, "$entries[1]");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
+}
+
 static void cb_check_source_location_common_case(void *ctx, int ffd,
                                                  int res_ret, void *res_data, size_t res_size,
                                                  void *data)
@@ -1614,6 +1635,46 @@ void flb_test_insert_id_incorrect_type()
     flb_destroy(ctx);
 }
 
+void flb_test_insert_id_multi_entries()
+{
+    int ret;
+    int size = sizeof(INSERTID_MULTI_ENTRIES) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_insert_id_multi_entries,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) INSERTID_MULTI_ENTRIES, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
 void flb_test_source_location_common_case()
 {
     int ret;
@@ -2445,6 +2506,7 @@ TEST_LIST = {
     {"insertId_common_case", flb_test_insert_id_common_case},
     {"empty_insertId", flb_test_empty_insert_id},
     {"insertId_incorrect_type_int", flb_test_insert_id_incorrect_type},
+    {"insertId_incorrect_multi_entries", flb_test_insert_id_multi_entries},
 
     /* test sourceLocation */
     {"sourceLocation_common_case", flb_test_source_location_common_case},


### PR DESCRIPTION
Reconstruct the code:
- unpack the entries first, validate each insertId. Calculate the number of valid logEntries
- If the valid logEntry size == 0, stop formatting
