### PR TITLE
Support timestamp

### DIFF
--- a/include/fluent-bit/flb_gzip.h
+++ b/include/fluent-bit/flb_gzip.h
@@ -27,6 +27,6 @@
 int flb_gzip_compress(void *in_data, size_t in_len,
                       void **out_data, size_t *out_len);
 int flb_gzip_uncompress(void *in_data, size_t in_len,
-                        void **out_data, size_t *out_len);
+                        void **out_data, size_t *out_size);
 
 #endif

--- a/plugins/out_stackdriver/CMakeLists.txt
+++ b/plugins/out_stackdriver/CMakeLists.txt
@@ -4,6 +4,7 @@ set(src
   stackdriver.c
   stackdriver_operation.c
   stackdriver_source_location.c
+  stackdriver_http_request.c
   stackdriver_helper.c
   )
 

--- a/plugins/out_stackdriver/CMakeLists.txt
+++ b/plugins/out_stackdriver/CMakeLists.txt
@@ -3,6 +3,7 @@ set(src
   stackdriver_conf.c
   stackdriver.c
   stackdriver_operation.c
+  stackdriver_source_location.c
   stackdriver_helper.c
   )
 

--- a/plugins/out_stackdriver/CMakeLists.txt
+++ b/plugins/out_stackdriver/CMakeLists.txt
@@ -5,6 +5,7 @@ set(src
   stackdriver_operation.c
   stackdriver_source_location.c
   stackdriver_http_request.c
+  stackdriver_timestamp.c
   stackdriver_helper.c
   )
 

--- a/plugins/out_stackdriver/CMakeLists.txt
+++ b/plugins/out_stackdriver/CMakeLists.txt
@@ -3,6 +3,7 @@ set(src
   stackdriver_conf.c
   stackdriver.c
   stackdriver_operation.c
+  stackdriver_helper.c
   )
 
 FLB_PLUGIN(out_stackdriver "${src}" "")

--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -778,10 +778,7 @@ static insert_id_status validate_insert_id(msgpack_object * insert_id_value,
         if (p->key.type != MSGPACK_OBJECT_STR) {
             continue;
         }
-        if (p->key.via.str.size == INSERT_ID_SIZE 
-            && strncmp(DEFAULT_INSERT_ID_KEY, 
-                       p->key.via.str.ptr, 
-                       p->key.via.str.size) == 0) {
+        if (validate_key(p->key, DEFAULT_INSERT_ID_KEY, INSERT_ID_SIZE)) {
             if (p->val.type == MSGPACK_OBJECT_STR && p->val.via.str.size > 0) {
                 *insert_id_value = p->val;
                 ret = INSERTID_VALID;
@@ -1210,7 +1207,7 @@ static int stackdriver_format(struct flb_config *config,
          * }
          */
         entry_size = 3;
-        
+
         /* Extract severity */
         severity_extracted = FLB_FALSE;
         if (ctx->severity_key

--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -32,6 +32,7 @@
 #include "stackdriver_conf.h"
 #include "stackdriver_operation.h"
 #include "stackdriver_source_location.h"
+#include "stackdriver_http_request.h"
 #include "stackdriver_helper.h"
 #include <mbedtls/base64.h>
 #include <mbedtls/sha256.h>
@@ -793,10 +794,12 @@ static insert_id_status validate_insert_id(msgpack_object * insert_id_value,
     return ret;
 }
                                                                                         
-static int pack_json_payload(int insert_id_extracted,
+static int pack_json_payload(int insert_id_extracted, 
                              int operation_extracted, int operation_extra_size,
                              int source_location_extracted, 
                              int source_location_extra_size,
+                             int http_request_extracted, 
+                             int http_request_extra_size,
                              msgpack_packer *mp_pck, msgpack_object *obj,
                              struct flb_stackdriver *ctx)
 {
@@ -826,13 +829,16 @@ static int pack_json_payload(int insert_id_extracted,
         /* more special fields are required to be added */
     };
 
-    if(insert_id_extracted == FLB_TRUE) {
+    if (insert_id_extracted == FLB_TRUE) {
         to_remove += 1;
     }
     if (operation_extracted == FLB_TRUE && operation_extra_size == 0) {
         to_remove += 1;
     }
-    if(source_location_extracted == FLB_TRUE && source_location_extra_size == 0) {
+    if (source_location_extracted == FLB_TRUE && source_location_extra_size == 0) {
+        to_remove += 1;
+    }
+    if (http_request_extracted == FLB_TRUE && http_request_extra_size == 0) {
         to_remove += 1;
     }
 
@@ -893,6 +899,18 @@ static int pack_json_payload(int insert_id_extracted,
                 msgpack_pack_object(mp_pck, kv->key);
                 pack_extra_source_location_subfields(mp_pck, &kv->val, 
                                                      source_location_extra_size);
+            }
+            continue;
+        }
+        
+        if (validate_key(kv->key, HTTPREQUEST_FIELD_IN_JSON, 
+                         HTTP_REQUEST_KEY_SIZE) 
+            && kv->val.type == MSGPACK_OBJECT_MAP) {
+
+            if(http_request_extra_size > 0) {
+                msgpack_pack_object(mp_pck, kv->key);
+                pack_extra_http_request_subfields(mp_pck, &kv->val, 
+                                                  http_request_extra_size);
             }
             continue;
         }
@@ -976,6 +994,11 @@ static int stackdriver_format(struct flb_config *config,
     flb_sds_t source_location_function;
     int source_location_extracted = FLB_FALSE;
     int source_location_extra_size = 0;
+    
+    /* Parameters for httpRequest */
+    struct http_request_field http_request;
+    int http_request_extracted = FLB_FALSE;
+    int http_request_extra_size = 0;
 
     /* Count number of records */
     array_size = flb_mp_count(data, bytes);
@@ -1282,6 +1305,15 @@ static int stackdriver_format(struct flb_config *config,
         if (source_location_extracted == FLB_TRUE) {
             entry_size += 1;
         }
+        
+        /* Extract httpRequest */
+        init_http_request(&http_request);
+        http_request_extra_size = 0;
+        http_request_extracted = extract_http_request(&http_request, obj, 
+                                                      &http_request_extra_size);
+        if (http_request_extracted == FLB_TRUE) {
+            entry_size += 1;
+        }
 
         /* Extract labels */
         labels_ptr = parse_labels(ctx, obj);
@@ -1324,6 +1356,11 @@ static int stackdriver_format(struct flb_config *config,
             add_source_location_field(&source_location_file, source_location_line, 
                                       &source_location_function, &mp_pck);
         }
+        
+        /* Add httpRequest field into the log entry */
+        if (http_request_extracted == FLB_TRUE) {
+            add_http_request_field(&http_request, &mp_pck);
+        }
 
         /* labels */
         if (labels_ptr != NULL) {
@@ -1337,6 +1374,7 @@ static int stackdriver_format(struct flb_config *config,
         flb_sds_destroy(operation_producer);
         flb_sds_destroy(source_location_file);
         flb_sds_destroy(source_location_function);
+        destroy_http_request(&http_request);
 
         /* jsonPayload */
         msgpack_pack_str(&mp_pck, 11);
@@ -1345,6 +1383,8 @@ static int stackdriver_format(struct flb_config *config,
                           operation_extracted, operation_extra_size,
                           source_location_extracted,
                           source_location_extra_size, 
+                          http_request_extracted, 
+                          http_request_extra_size,
                           &mp_pck, obj, ctx);
 
         /* avoid modifying the original tag */

--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -49,7 +49,9 @@
 #define OPERATION_FIELD_IN_JSON "logging.googleapis.com/operation"
 #define LOCAL_RESOURCE_ID_KEY "logging.googleapis.com/local_resource_id"
 #define DEFAULT_LABELS_KEY "logging.googleapis.com/labels"
+
 #define LEN_LOCAL_RESOURCE_ID_KEY 40
+#define OPERATION_KEY_SIZE 32
 
 #define K8S_CONTAINER "k8s_container"
 #define K8S_NODE      "k8s_node"
@@ -129,5 +131,6 @@ struct local_resource_id_list {
     flb_sds_t val;
     struct mk_list _head;
 };
+
 
 #endif

--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -49,7 +49,8 @@
 #define OPERATION_FIELD_IN_JSON "logging.googleapis.com/operation"
 #define LOCAL_RESOURCE_ID_KEY "logging.googleapis.com/local_resource_id"
 #define DEFAULT_LABELS_KEY "logging.googleapis.com/labels"
-
+#define DEFAULT_INSERT_ID_KEY "logging.googleapis.com/insertId"
+#define INSERT_ID_SIZE 31
 #define LEN_LOCAL_RESOURCE_ID_KEY 40
 #define OPERATION_KEY_SIZE 32
 
@@ -132,5 +133,10 @@ struct local_resource_id_list {
     struct mk_list _head;
 };
 
+typedef enum {
+    INSERTID_VALID = 0,
+    INSERTID_INVALID = 1,
+    INSERTID_NOT_PRESENT = 2
+} insert_id_status;
 
 #endif

--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -50,9 +50,11 @@
 #define LOCAL_RESOURCE_ID_KEY "logging.googleapis.com/local_resource_id"
 #define DEFAULT_LABELS_KEY "logging.googleapis.com/labels"
 #define DEFAULT_INSERT_ID_KEY "logging.googleapis.com/insertId"
+#define SOURCELOCATION_FIELD_IN_JSON "logging.googleapis.com/sourceLocation"
 #define INSERT_ID_SIZE 31
 #define LEN_LOCAL_RESOURCE_ID_KEY 40
 #define OPERATION_KEY_SIZE 32
+#define SOURCE_LOCATION_SIZE 37
 
 #define K8S_CONTAINER "k8s_container"
 #define K8S_NODE      "k8s_node"

--- a/plugins/out_stackdriver/stackdriver.h
+++ b/plugins/out_stackdriver/stackdriver.h
@@ -51,10 +51,12 @@
 #define DEFAULT_LABELS_KEY "logging.googleapis.com/labels"
 #define DEFAULT_INSERT_ID_KEY "logging.googleapis.com/insertId"
 #define SOURCELOCATION_FIELD_IN_JSON "logging.googleapis.com/sourceLocation"
+#define HTTPREQUEST_FIELD_IN_JSON "logging.googleapis.com/http_request"
 #define INSERT_ID_SIZE 31
 #define LEN_LOCAL_RESOURCE_ID_KEY 40
 #define OPERATION_KEY_SIZE 32
 #define SOURCE_LOCATION_SIZE 37
+#define HTTP_REQUEST_KEY_SIZE 35
 
 #define K8S_CONTAINER "k8s_container"
 #define K8S_NODE      "k8s_node"

--- a/plugins/out_stackdriver/stackdriver_helper.c
+++ b/plugins/out_stackdriver/stackdriver_helper.c
@@ -1,0 +1,62 @@
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2020 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+
+#include "stackdriver.h"
+
+int equal_obj_str(msgpack_object obj, const char *str, const int size) {
+    if (obj.type != MSGPACK_OBJECT_STR) {
+        return FLB_FALSE;
+    }
+    if (size != obj.via.str.size 
+        || strncmp(str, obj.via.str.ptr, obj.via.str.size) != 0) {
+        return FLB_FALSE;
+    }
+    return FLB_TRUE;
+}
+
+int validate_key(msgpack_object obj, const char *str, const int size) {
+    return equal_obj_str(obj, str, size);
+}
+
+void try_assign_subfield_str(msgpack_object obj, flb_sds_t *subfield) {
+    if (obj.type == MSGPACK_OBJECT_STR) {
+        *subfield = flb_sds_copy(*subfield, obj.via.str.ptr, 
+                                 obj.via.str.size);
+    }
+}
+
+void try_assign_subfield_bool(msgpack_object obj, int *subfield) {
+    if (obj.type == MSGPACK_OBJECT_BOOLEAN) {
+        if (obj.via.boolean) {
+            *subfield = FLB_TRUE;
+        }
+        else {
+            *subfield = FLB_FALSE;
+        }
+    }
+}
+
+void try_assign_subfield_int(msgpack_object obj, int64_t *subfield) {
+    if (obj.type == MSGPACK_OBJECT_STR) {
+        *subfield = atoll(obj.via.str.ptr);
+    }
+    else if (obj.type == MSGPACK_OBJECT_POSITIVE_INTEGER) {
+        *subfield = obj.via.i64;
+    }
+}

--- a/plugins/out_stackdriver/stackdriver_helper.h
+++ b/plugins/out_stackdriver/stackdriver_helper.h
@@ -1,0 +1,52 @@
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2020 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+
+#ifndef FLB_STD_HELPER_H
+#define FLB_STD_HELPER_H
+
+#include "stackdriver.h"
+
+/* 
+ * Compare obj->via.str and str. 
+ * Return FLB_TRUE if they are equal. 
+ * Return FLB_FALSE if obj->type is not string or they are not equal
+ */
+int equal_obj_str(msgpack_object obj, const char *str, const int size);
+
+int validate_key(msgpack_object obj, const char *str, const int size);
+
+/* 
+ * if obj->type is string, assign obj->val to subfield 
+ * Otherwise leave the subfield untouched
+ */
+void try_assign_subfield_str(msgpack_object obj, flb_sds_t *subfield);
+
+/* 
+ * if obj->type is boolean, assign obj->val to subfield 
+ * Otherwise leave the subfield untouched
+ */
+void try_assign_subfield_bool(msgpack_object obj, int *subfield);
+
+/* 
+ * if obj->type is valid, assign obj->val to subfield 
+ * Otherwise leave the subfield untouched
+ */
+void try_assign_subfield_int(msgpack_object obj, int64_t *subfield);
+
+#endif

--- a/plugins/out_stackdriver/stackdriver_http_request.c
+++ b/plugins/out_stackdriver/stackdriver_http_request.c
@@ -1,0 +1,373 @@
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2020 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+#include <fluent-bit/flb_regex.h>
+#include "stackdriver.h"
+#include "stackdriver_helper.h"
+#include "stackdriver_http_request.h"
+
+typedef enum {
+    NO_HTTPREQUEST = 1,
+    HTTPREQUEST_EXISTS = 2
+} http_request_status;
+
+void init_http_request(struct http_request_field *http_request)
+{
+    http_request->latency = flb_sds_create("");
+    http_request->protocol = flb_sds_create("");
+    http_request->referer = flb_sds_create("");
+    http_request->remoteIp = flb_sds_create("");
+    http_request->requestMethod = flb_sds_create("");
+    http_request->requestUrl = flb_sds_create("");
+    http_request->serverIp = flb_sds_create("");
+    http_request->userAgent = flb_sds_create("");
+
+    http_request->cacheFillBytes = 0;
+    http_request->requestSize = 0;
+    http_request->responseSize = 0;
+    http_request->status = 0;
+
+    http_request->cacheHit = FLB_FALSE;
+    http_request->cacheLookup = FLB_FALSE;
+    http_request->cacheValidatedWithOriginServer = FLB_FALSE;
+}
+
+void destroy_http_request(struct http_request_field *http_request)
+{
+    flb_sds_destroy(http_request->latency);
+    flb_sds_destroy(http_request->protocol);
+    flb_sds_destroy(http_request->referer);
+    flb_sds_destroy(http_request->remoteIp);
+    flb_sds_destroy(http_request->requestMethod);
+    flb_sds_destroy(http_request->requestUrl);
+    flb_sds_destroy(http_request->serverIp);
+    flb_sds_destroy(http_request->userAgent);
+}
+
+void add_http_request_field(struct http_request_field *http_request, 
+                            msgpack_packer *mp_pck)
+{    
+    msgpack_pack_str(mp_pck, 11);
+    msgpack_pack_str_body(mp_pck, "httpRequest", 11);
+
+    if (flb_sds_is_empty(http_request->latency) == FLB_TRUE) {
+        msgpack_pack_map(mp_pck, 14);
+    }
+    else {
+        msgpack_pack_map(mp_pck, 15);
+
+        msgpack_pack_str(mp_pck, HTTP_REQUEST_LATENCY_SIZE);
+        msgpack_pack_str_body(mp_pck, HTTP_REQUEST_LATENCY, 
+                              HTTP_REQUEST_LATENCY_SIZE);
+        msgpack_pack_str(mp_pck, flb_sds_len(http_request->latency));
+        msgpack_pack_str_body(mp_pck, http_request->latency, 
+                              flb_sds_len(http_request->latency));
+    }
+
+    /* String sub-fields */
+    msgpack_pack_str(mp_pck, HTTP_REQUEST_REQUEST_METHOD_SIZE);
+    msgpack_pack_str_body(mp_pck, HTTP_REQUEST_REQUEST_METHOD, 
+                          HTTP_REQUEST_REQUEST_METHOD_SIZE);
+    msgpack_pack_str(mp_pck, flb_sds_len(http_request->requestMethod));
+    msgpack_pack_str_body(mp_pck, http_request->requestMethod, 
+                          flb_sds_len(http_request->requestMethod));
+
+    msgpack_pack_str(mp_pck, HTTP_REQUEST_REQUEST_URL_SIZE);
+    msgpack_pack_str_body(mp_pck, HTTP_REQUEST_REQUEST_URL, 
+                          HTTP_REQUEST_REQUEST_URL_SIZE);
+    msgpack_pack_str(mp_pck, flb_sds_len(http_request->requestUrl));
+    msgpack_pack_str_body(mp_pck, http_request->requestUrl, 
+                          flb_sds_len(http_request->requestUrl));
+
+    msgpack_pack_str(mp_pck, HTTP_REQUEST_USER_AGENT_SIZE);
+    msgpack_pack_str_body(mp_pck, HTTP_REQUEST_USER_AGENT, 
+                          HTTP_REQUEST_USER_AGENT_SIZE);
+    msgpack_pack_str(mp_pck, flb_sds_len(http_request->userAgent));
+    msgpack_pack_str_body(mp_pck, http_request->userAgent, 
+                          flb_sds_len(http_request->userAgent));
+
+    msgpack_pack_str(mp_pck, HTTP_REQUEST_REMOTE_IP_SIZE);
+    msgpack_pack_str_body(mp_pck, HTTP_REQUEST_REMOTE_IP, 
+                          HTTP_REQUEST_REMOTE_IP_SIZE);
+    msgpack_pack_str(mp_pck, flb_sds_len(http_request->remoteIp));
+    msgpack_pack_str_body(mp_pck, http_request->remoteIp, 
+                          flb_sds_len(http_request->remoteIp));
+
+    msgpack_pack_str(mp_pck, HTTP_REQUEST_SERVER_IP_SIZE);
+    msgpack_pack_str_body(mp_pck, HTTP_REQUEST_SERVER_IP, 
+                          HTTP_REQUEST_SERVER_IP_SIZE);
+    msgpack_pack_str(mp_pck, flb_sds_len(http_request->serverIp));
+    msgpack_pack_str_body(mp_pck, http_request->serverIp, 
+                          flb_sds_len(http_request->serverIp));
+
+    msgpack_pack_str(mp_pck, HTTP_REQUEST_REFERER_SIZE);
+    msgpack_pack_str_body(mp_pck, HTTP_REQUEST_REFERER, 
+                          HTTP_REQUEST_REFERER_SIZE);
+    msgpack_pack_str(mp_pck, flb_sds_len(http_request->referer));
+    msgpack_pack_str_body(mp_pck, http_request->referer, 
+                          flb_sds_len(http_request->referer));
+
+    msgpack_pack_str(mp_pck, HTTP_REQUEST_PROTOCOL_SIZE);
+    msgpack_pack_str_body(mp_pck, HTTP_REQUEST_PROTOCOL, 
+                          HTTP_REQUEST_PROTOCOL_SIZE);
+    msgpack_pack_str(mp_pck, flb_sds_len(http_request->protocol));
+    msgpack_pack_str_body(mp_pck, http_request->protocol, 
+                          flb_sds_len(http_request->protocol));
+
+    /* Integer sub-fields */
+    msgpack_pack_str(mp_pck, HTTP_REQUEST_REQUESTSIZE_SIZE);
+    msgpack_pack_str_body(mp_pck, HTTP_REQUEST_REQUESTSIZE, 
+                          HTTP_REQUEST_REQUESTSIZE_SIZE);
+    msgpack_pack_int64(mp_pck, http_request->requestSize);
+
+    msgpack_pack_str(mp_pck, HTTP_REQUEST_RESPONSESIZE_SIZE);
+    msgpack_pack_str_body(mp_pck, HTTP_REQUEST_RESPONSESIZE, 
+                          HTTP_REQUEST_RESPONSESIZE_SIZE);
+    msgpack_pack_int64(mp_pck, http_request->responseSize);
+
+    msgpack_pack_str(mp_pck, HTTP_REQUEST_STATUS_SIZE);
+    msgpack_pack_str_body(mp_pck, HTTP_REQUEST_STATUS, HTTP_REQUEST_STATUS_SIZE);
+    msgpack_pack_int64(mp_pck, http_request->status);
+
+    msgpack_pack_str(mp_pck, HTTP_REQUEST_CACHE_FILL_BYTES_SIZE);
+    msgpack_pack_str_body(mp_pck, HTTP_REQUEST_CACHE_FILL_BYTES, 
+                          HTTP_REQUEST_CACHE_FILL_BYTES_SIZE);
+    msgpack_pack_int64(mp_pck, http_request->cacheFillBytes);
+
+    /* Boolean sub-fields */
+    msgpack_pack_str(mp_pck, HTTP_REQUEST_CACHE_LOOKUP_SIZE);
+    msgpack_pack_str_body(mp_pck, HTTP_REQUEST_CACHE_LOOKUP, 
+                          HTTP_REQUEST_CACHE_LOOKUP_SIZE);
+    if (http_request->cacheLookup == FLB_TRUE) {
+        msgpack_pack_true(mp_pck);
+    }
+    else {
+        msgpack_pack_false(mp_pck);
+    }
+
+    msgpack_pack_str(mp_pck, HTTP_REQUEST_CACHE_HIT_SIZE);
+    msgpack_pack_str_body(mp_pck, HTTP_REQUEST_CACHE_HIT, 
+                          HTTP_REQUEST_CACHE_HIT_SIZE);
+    if (http_request->cacheLookup == FLB_TRUE) {
+        msgpack_pack_true(mp_pck);
+    }
+    else {
+        msgpack_pack_false(mp_pck);
+    }
+
+    msgpack_pack_str(mp_pck, HTTP_REQUEST_CACHE_VALIDATE_WITH_ORIGIN_SERVER_SIZE);
+    msgpack_pack_str_body(mp_pck, HTTP_REQUEST_CACHE_VALIDATE_WITH_ORIGIN_SERVER, 
+                          HTTP_REQUEST_CACHE_VALIDATE_WITH_ORIGIN_SERVER_SIZE);
+    if (http_request->cacheValidatedWithOriginServer == FLB_TRUE) {
+        msgpack_pack_true(mp_pck);
+    }
+    else {
+        msgpack_pack_false(mp_pck);
+    }
+}
+
+/* latency should be in the format: 
+ *      whitespace (opt.) + integer + point & decimal (opt.)
+ *      + whitespace (opt.) + "s" + whitespace (opt.) 
+ */
+static void validate_latency(msgpack_object_str latency_in_payload, 
+                             struct http_request_field *http_request) {
+    flb_sds_t pattern = flb_sds_create("^\\s*\\d+(.\\d+)?\\s*s\\s*$");
+    char extract_latency[latency_in_payload.size];
+    struct flb_regex *regex;
+
+    int status = 0;
+    int i = 0, j = 0;
+
+    regex = flb_regex_create(pattern);
+    status = flb_regex_match(regex, latency_in_payload.ptr, latency_in_payload.size);
+    flb_regex_destroy(regex);
+    flb_sds_destroy(pattern);
+
+    if (status == 1) {
+        for (; i < latency_in_payload.size; ++ i) {
+            if (latency_in_payload.ptr[i] == '.' || latency_in_payload.ptr[i] == 's' 
+                || isdigit(latency_in_payload.ptr[i])) {
+                extract_latency[j] = latency_in_payload.ptr[i];
+                ++ j;
+            }
+        }
+        http_request->latency = flb_sds_copy(http_request->latency, extract_latency, j);
+    }
+}
+
+/* Return true if httpRequest extracted */
+int extract_http_request(struct http_request_field *http_request, 
+                         msgpack_object *obj, int *extra_subfields)
+{
+    http_request_status op_status = NO_HTTPREQUEST;
+    msgpack_object_kv *p;
+    msgpack_object_kv *pend;
+    msgpack_object_kv *tmp_p;
+    msgpack_object_kv *tmp_pend;
+
+    if (obj->via.map.size == 0) {
+        return FLB_FALSE;
+    }
+
+    p = obj->via.map.ptr;
+    pend = obj->via.map.ptr + obj->via.map.size;
+
+    for (; p < pend && op_status == NO_HTTPREQUEST; ++p) {
+
+        if (p->val.type != MSGPACK_OBJECT_MAP
+            || !validate_key(p->key, HTTPREQUEST_FIELD_IN_JSON, 
+                             HTTP_REQUEST_KEY_SIZE)) {
+
+            continue;
+        }
+
+        op_status = HTTPREQUEST_EXISTS;
+        msgpack_object sub_field = p->val;
+
+        tmp_p = sub_field.via.map.ptr;
+        tmp_pend = sub_field.via.map.ptr + sub_field.via.map.size;
+
+        /* Validate the subfields of httpRequest */
+        for (; tmp_p < tmp_pend; ++tmp_p) {
+            if (tmp_p->key.type != MSGPACK_OBJECT_STR) {
+                continue;
+            }
+
+            if (validate_key(tmp_p->key, HTTP_REQUEST_LATENCY, 
+                             HTTP_REQUEST_LATENCY_SIZE)) {                
+                if (tmp_p->val.type != MSGPACK_OBJECT_STR) {
+                    continue;
+                }
+                validate_latency(tmp_p->val.via.str, http_request);
+            }
+            else if (validate_key(tmp_p->key, HTTP_REQUEST_PROTOCOL, 
+                                  HTTP_REQUEST_PROTOCOL_SIZE)) {
+                try_assign_subfield_str(tmp_p->val, &http_request->protocol);
+            }
+            else if (validate_key(tmp_p->key, HTTP_REQUEST_REFERER, 
+                                  HTTP_REQUEST_REFERER_SIZE)) {
+                try_assign_subfield_str(tmp_p->val, &http_request->referer);
+            }
+            else if (validate_key(tmp_p->key, HTTP_REQUEST_REMOTE_IP, 
+                                  HTTP_REQUEST_REMOTE_IP_SIZE)) {
+                try_assign_subfield_str(tmp_p->val, &http_request->remoteIp);
+            }
+            else if (validate_key(tmp_p->key, HTTP_REQUEST_REQUEST_METHOD, 
+                                  HTTP_REQUEST_REQUEST_METHOD_SIZE)) {
+                try_assign_subfield_str(tmp_p->val, &http_request->requestMethod);
+            }
+            else if (validate_key(tmp_p->key, HTTP_REQUEST_REQUEST_URL, 
+                                  HTTP_REQUEST_REQUEST_URL_SIZE)) {
+                try_assign_subfield_str(tmp_p->val, &http_request->requestUrl);
+            }
+            else if (validate_key(tmp_p->key, HTTP_REQUEST_SERVER_IP, 
+                                  HTTP_REQUEST_SERVER_IP_SIZE)) {
+                try_assign_subfield_str(tmp_p->val, &http_request->serverIp);
+            }
+            else if (validate_key(tmp_p->key, HTTP_REQUEST_USER_AGENT, 
+                                  HTTP_REQUEST_USER_AGENT_SIZE)) {
+                try_assign_subfield_str(tmp_p->val, &http_request->userAgent);
+            }
+
+            else if (validate_key(tmp_p->key, HTTP_REQUEST_CACHE_FILL_BYTES, 
+                                  HTTP_REQUEST_CACHE_FILL_BYTES_SIZE)) {
+                try_assign_subfield_int(tmp_p->val, &http_request->cacheFillBytes);
+            }
+            else if (validate_key(tmp_p->key, HTTP_REQUEST_REQUESTSIZE, 
+                                  HTTP_REQUEST_REQUESTSIZE_SIZE)) {
+                try_assign_subfield_int(tmp_p->val, &http_request->requestSize);
+            }
+            else if (validate_key(tmp_p->key, HTTP_REQUEST_RESPONSESIZE, 
+                                  HTTP_REQUEST_RESPONSESIZE_SIZE)) {
+                try_assign_subfield_int(tmp_p->val, &http_request->responseSize);
+            }
+            else if (validate_key(tmp_p->key, HTTP_REQUEST_STATUS, 
+                                  HTTP_REQUEST_STATUS_SIZE)) {
+                try_assign_subfield_int(tmp_p->val, &http_request->status);
+            }
+
+            else if (validate_key(tmp_p->key, HTTP_REQUEST_CACHE_HIT, 
+                                  HTTP_REQUEST_CACHE_HIT_SIZE)) {
+                try_assign_subfield_bool(tmp_p->val, &http_request->cacheHit);
+            }
+            else if (validate_key(tmp_p->key, HTTP_REQUEST_CACHE_LOOKUP, 
+                                  HTTP_REQUEST_CACHE_LOOKUP_SIZE)) {
+                try_assign_subfield_bool(tmp_p->val, &http_request->cacheLookup);
+            }
+            else if (validate_key(tmp_p->key, HTTP_REQUEST_CACHE_VALIDATE_WITH_ORIGIN_SERVER, 
+                                  HTTP_REQUEST_CACHE_VALIDATE_WITH_ORIGIN_SERVER_SIZE)) {
+                try_assign_subfield_bool(tmp_p->val, 
+                                         &http_request->cacheValidatedWithOriginServer);
+            }
+
+            else {
+                *extra_subfields += 1;
+            }
+        }
+    }
+
+    return op_status == HTTPREQUEST_EXISTS;
+}
+
+void pack_extra_http_request_subfields(msgpack_packer *mp_pck, 
+                                       msgpack_object *http_request, 
+                                       int extra_subfields) {
+    msgpack_object_kv *p = http_request->via.map.ptr;
+    msgpack_object_kv *const pend = http_request->via.map.ptr + http_request->via.map.size;
+
+    msgpack_pack_map(mp_pck, extra_subfields);
+
+    for (; p < pend; ++p) {
+        if (validate_key(p->key, HTTP_REQUEST_LATENCY, 
+                         HTTP_REQUEST_LATENCY_SIZE)
+            || validate_key(p->key, HTTP_REQUEST_PROTOCOL, 
+                            HTTP_REQUEST_PROTOCOL_SIZE)
+            || validate_key(p->key, HTTP_REQUEST_REFERER, 
+                            HTTP_REQUEST_REFERER_SIZE)
+            || validate_key(p->key, HTTP_REQUEST_REMOTE_IP, 
+                            HTTP_REQUEST_REMOTE_IP_SIZE)
+            || validate_key(p->key, HTTP_REQUEST_REQUEST_METHOD, 
+                            HTTP_REQUEST_REQUEST_METHOD_SIZE)
+            || validate_key(p->key, HTTP_REQUEST_REQUEST_URL, 
+                            HTTP_REQUEST_REQUEST_URL_SIZE)
+            || validate_key(p->key, HTTP_REQUEST_SERVER_IP, 
+                            HTTP_REQUEST_SERVER_IP_SIZE)
+            || validate_key(p->key, HTTP_REQUEST_USER_AGENT, 
+                            HTTP_REQUEST_USER_AGENT_SIZE)
+            || validate_key(p->key, HTTP_REQUEST_CACHE_FILL_BYTES, 
+                            HTTP_REQUEST_CACHE_FILL_BYTES_SIZE)
+            || validate_key(p->key, HTTP_REQUEST_REQUESTSIZE, 
+                            HTTP_REQUEST_REQUESTSIZE_SIZE)
+            || validate_key(p->key, HTTP_REQUEST_RESPONSESIZE, 
+                            HTTP_REQUEST_RESPONSESIZE_SIZE)
+            || validate_key(p->key, HTTP_REQUEST_STATUS, 
+                            HTTP_REQUEST_STATUS_SIZE)
+            || validate_key(p->key, HTTP_REQUEST_CACHE_HIT, 
+                            HTTP_REQUEST_CACHE_HIT_SIZE)
+            || validate_key(p->key, HTTP_REQUEST_CACHE_LOOKUP, 
+                            HTTP_REQUEST_CACHE_LOOKUP_SIZE)
+            || validate_key(p->key, HTTP_REQUEST_CACHE_VALIDATE_WITH_ORIGIN_SERVER, 
+                            HTTP_REQUEST_CACHE_VALIDATE_WITH_ORIGIN_SERVER_SIZE)) {
+
+            continue;
+        }
+
+        msgpack_pack_object(mp_pck, p->key);
+        msgpack_pack_object(mp_pck, p->val);
+    }
+}

--- a/plugins/out_stackdriver/stackdriver_http_request.h
+++ b/plugins/out_stackdriver/stackdriver_http_request.h
@@ -1,0 +1,119 @@
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2020 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+
+#ifndef FLB_STD_HTTPREQUEST_H
+#define FLB_STD_HTTPREQUEST_H
+
+#include "stackdriver.h"
+
+/* subfield name and size */
+#define HTTP_REQUEST_LATENCY "latency"
+#define HTTP_REQUEST_PROTOCOL "protocol"
+#define HTTP_REQUEST_REFERER "referer"
+#define HTTP_REQUEST_REMOTE_IP "remoteIp"
+#define HTTP_REQUEST_REQUEST_METHOD "requestMethod"
+#define HTTP_REQUEST_REQUEST_URL "requestUrl"
+#define HTTP_REQUEST_SERVER_IP "serverIp"
+#define HTTP_REQUEST_USER_AGENT "userAgent"
+#define HTTP_REQUEST_CACHE_FILL_BYTES "cacheFillBytes"
+#define HTTP_REQUEST_REQUESTSIZE "requestSize"
+#define HTTP_REQUEST_RESPONSESIZE "responseSize"
+#define HTTP_REQUEST_STATUS "status"
+#define HTTP_REQUEST_CACHE_HIT "cacheHit"
+#define HTTP_REQUEST_CACHE_LOOKUP "cacheLookup"
+#define HTTP_REQUEST_CACHE_VALIDATE_WITH_ORIGIN_SERVER "cacheValidatedWithOriginServer"
+
+#define HTTP_REQUEST_LATENCY_SIZE 7
+#define HTTP_REQUEST_PROTOCOL_SIZE  8
+#define HTTP_REQUEST_REFERER_SIZE 7
+#define HTTP_REQUEST_REMOTE_IP_SIZE 8 
+#define HTTP_REQUEST_REQUEST_METHOD_SIZE 13
+#define HTTP_REQUEST_REQUEST_URL_SIZE 10
+#define HTTP_REQUEST_SERVER_IP_SIZE 8
+#define HTTP_REQUEST_USER_AGENT_SIZE 9
+#define HTTP_REQUEST_CACHE_FILL_BYTES_SIZE 14
+#define HTTP_REQUEST_REQUESTSIZE_SIZE 11
+#define HTTP_REQUEST_RESPONSESIZE_SIZE 12
+#define HTTP_REQUEST_STATUS_SIZE 6
+#define HTTP_REQUEST_CACHE_HIT_SIZE 8
+#define HTTP_REQUEST_CACHE_LOOKUP_SIZE 11
+#define HTTP_REQUEST_CACHE_VALIDATE_WITH_ORIGIN_SERVER_SIZE 30
+
+
+struct http_request_field {
+    flb_sds_t latency;
+    flb_sds_t protocol;
+    flb_sds_t referer;
+    flb_sds_t remoteIp;
+    flb_sds_t requestMethod;
+    flb_sds_t requestUrl;
+    flb_sds_t serverIp;
+    flb_sds_t userAgent;
+
+    int64_t cacheFillBytes;
+    int64_t requestSize;
+    int64_t responseSize;
+    int64_t status;
+
+    int cacheHit;
+    int cacheLookup;
+    int cacheValidatedWithOriginServer;
+};
+
+void init_http_request(struct http_request_field *http_request);
+void destroy_http_request(struct http_request_field *http_request);
+
+/* 
+ *  Add httpRequest field to the entries.
+ *  The structure of httpRequest is as shown in struct http_request_field
+ */   
+void add_http_request_field(struct http_request_field *http_request, 
+                            msgpack_packer *mp_pck);
+
+/*
+ *  Extract the httpRequest field from the jsonPayload.
+ *  If the httpRequest field exists, return TRUE and store the subfields.
+ *  If there are extra subfields, count the number.
+ */
+int extract_http_request(struct http_request_field *http_request, 
+                         msgpack_object *obj, int *extra_subfields);
+
+/*
+ *  When there are extra subfields, we will preserve the extra subfields inside jsonPayload
+ *  For example, if the jsonPayload is as followed：
+ *  jsonPayload {
+ *      "logging.googleapis.com/http_request": {
+ *          "requestMethod": "GET",
+ *          "latency": "1s",
+ *          "cacheLookup": true,
+ *          "extra": "some string"  #extra subfield
+ *      }
+ *  }
+ *  We will preserve the extra subfields. The jsonPayload after extracting is:
+ *  jsonPayload {
+ *      "logging.googleapis.com/http_request": {
+ *          "extra": "some string" 
+ *      }
+ *  }
+ */
+void pack_extra_http_request_subfields(msgpack_packer *mp_pck, 
+                                       msgpack_object *http_request, 
+                                       int extra_subfields);
+
+#endif

--- a/plugins/out_stackdriver/stackdriver_operation.c
+++ b/plugins/out_stackdriver/stackdriver_operation.c
@@ -16,6 +16,7 @@
  *  limitations under the License.
  */
 #include "stackdriver.h"
+#include "stackdriver_helper.h"
 #include "stackdriver_operation.h"
 
 typedef enum {
@@ -23,24 +24,28 @@ typedef enum {
     OPERATION_EXISTED = 2
 } operation_status;
 
-
 void add_operation_field(flb_sds_t *operation_id, flb_sds_t *operation_producer, 
                          int *operation_first, int *operation_last, 
                          msgpack_packer *mp_pck)
 {    
     msgpack_pack_str(mp_pck, 9);
     msgpack_pack_str_body(mp_pck, "operation", 9);
+
     msgpack_pack_map(mp_pck, 4);
-    msgpack_pack_str(mp_pck, 2);
-    msgpack_pack_str_body(mp_pck, "id", 2);
+
+    msgpack_pack_str(mp_pck, OPERATION_ID_SIZE);
+    msgpack_pack_str_body(mp_pck, OPERATION_ID, OPERATION_ID_SIZE);
     msgpack_pack_str(mp_pck, flb_sds_len(*operation_id));
     msgpack_pack_str_body(mp_pck, *operation_id, flb_sds_len(*operation_id));
-    msgpack_pack_str(mp_pck, 8);
-    msgpack_pack_str_body(mp_pck, "producer", 8);
+
+    msgpack_pack_str(mp_pck, OPERATION_PRODUCER_SIZE);
+    msgpack_pack_str_body(mp_pck, OPERATION_PRODUCER, OPERATION_PRODUCER_SIZE);
     msgpack_pack_str(mp_pck, flb_sds_len(*operation_producer));
-    msgpack_pack_str_body(mp_pck, *operation_producer, flb_sds_len(*operation_producer));
-    msgpack_pack_str(mp_pck, 5);
-    msgpack_pack_str_body(mp_pck, "first", 5);
+    msgpack_pack_str_body(mp_pck, *operation_producer, 
+                          flb_sds_len(*operation_producer));
+
+    msgpack_pack_str(mp_pck, OPERATION_FIRST_SIZE);
+    msgpack_pack_str_body(mp_pck, OPERATION_FIRST, OPERATION_FIRST_SIZE);
     if (*operation_first == FLB_TRUE) {
         msgpack_pack_true(mp_pck);
     }
@@ -48,8 +53,8 @@ void add_operation_field(flb_sds_t *operation_id, flb_sds_t *operation_producer,
         msgpack_pack_false(mp_pck);
     }
     
-    msgpack_pack_str(mp_pck, 4);
-    msgpack_pack_str_body(mp_pck, "last", 4);
+    msgpack_pack_str(mp_pck, OPERATION_LAST_SIZE);
+    msgpack_pack_str_body(mp_pck, OPERATION_LAST, OPERATION_LAST_SIZE);
     if (*operation_last == FLB_TRUE) {
         msgpack_pack_true(mp_pck);
     }
@@ -64,81 +69,75 @@ int extract_operation(flb_sds_t *operation_id, flb_sds_t *operation_producer,
                       msgpack_object *obj, int *extra_subfields)
 {
     operation_status op_status = NO_OPERATION;
+    msgpack_object_kv *p;
+    msgpack_object_kv *pend;
+    msgpack_object_kv *tmp_p;
+    msgpack_object_kv *tmp_pend;
 
-    if (obj->via.map.size != 0) {    	
-        msgpack_object_kv *p = obj->via.map.ptr;
-        msgpack_object_kv *const pend = obj->via.map.ptr + obj->via.map.size;
+    if (obj->via.map.size == 0) {    	
+        return FLB_FALSE;
+    }
+    p = obj->via.map.ptr;
+    pend = obj->via.map.ptr + obj->via.map.size;
 
-        for (; p < pend && op_status == NO_OPERATION; ++p) {
-            if (p->val.type == MSGPACK_OBJECT_MAP && p->key.type == MSGPACK_OBJECT_STR
-                && strncmp(OPERATION_FIELD_IN_JSON, p->key.via.str.ptr, p->key.via.str.size) == 0) {
-                
-                op_status = OPERATION_EXISTED;
-                msgpack_object sub_field = p->val;
-                
-                msgpack_object_kv *tmp_p = sub_field.via.map.ptr;
-                msgpack_object_kv *const tmp_pend = sub_field.via.map.ptr + sub_field.via.map.size;
+    for (; p < pend && op_status == NO_OPERATION; ++p) {
 
-                /* Validate the subfields of operation */
-                for (; tmp_p < tmp_pend; ++tmp_p) {
-                    if (tmp_p->key.type != MSGPACK_OBJECT_STR) {
-                        continue;
-                    }
-                    if (strncmp("id", tmp_p->key.via.str.ptr, tmp_p->key.via.str.size) == 0) {
-                        if (tmp_p->val.type != MSGPACK_OBJECT_STR) {
-                            continue;
-                        }
-                        *operation_id = flb_sds_copy(*operation_id, tmp_p->val.via.str.ptr, tmp_p->val.via.str.size);
-                    }
-                    else if (strncmp("producer", tmp_p->key.via.str.ptr, tmp_p->key.via.str.size) == 0) {
-                        if (tmp_p->val.type != MSGPACK_OBJECT_STR) {
-                            continue;
-                        }
-                        *operation_producer = flb_sds_copy(*operation_producer, tmp_p->val.via.str.ptr, tmp_p->val.via.str.size);
-                    }
-                    else if (strncmp("first", tmp_p->key.via.str.ptr, tmp_p->key.via.str.size) == 0) {
-                        if (tmp_p->val.type != MSGPACK_OBJECT_BOOLEAN) {
-                            continue;
-                        }
-                        if (tmp_p->val.via.boolean) {
-                            *operation_first = FLB_TRUE;
-                        }
-                    }
-                    else if (strncmp("last", tmp_p->key.via.str.ptr, tmp_p->key.via.str.size) == 0) {
-                        if (tmp_p->val.type != MSGPACK_OBJECT_BOOLEAN) {
-                            continue;
-                        }
-                        if (tmp_p->val.via.boolean) {
-                            *operation_last = FLB_TRUE;
-                        }
-                    }
-                    else {
-                        /* extra sub-fields */ 
-                        *extra_subfields += 1;
-                    }
+        if (p->val.type != MSGPACK_OBJECT_MAP
+            || !validate_key(p->key, OPERATION_FIELD_IN_JSON, 
+                             OPERATION_KEY_SIZE)) {
+            continue;
+        }
 
-                }
+        op_status = OPERATION_EXISTED;
+        msgpack_object sub_field = p->val;
+        
+        tmp_p = sub_field.via.map.ptr;
+        tmp_pend = sub_field.via.map.ptr + sub_field.via.map.size;
+
+        /* Validate the subfields of operation */
+        for (; tmp_p < tmp_pend; ++tmp_p) {
+            if (tmp_p->key.type != MSGPACK_OBJECT_STR) {
+                continue;
+            }
+
+            if (validate_key(tmp_p->key, OPERATION_ID, OPERATION_ID_SIZE)) {
+                try_assign_subfield_str(tmp_p->val, operation_id);
+            }
+            else if (validate_key(tmp_p->key, OPERATION_PRODUCER, 
+                                  OPERATION_PRODUCER_SIZE)) {
+                try_assign_subfield_str(tmp_p->val, operation_producer);
+            }
+            else if (validate_key(tmp_p->key, OPERATION_FIRST, OPERATION_FIRST_SIZE)) {
+                try_assign_subfield_bool(tmp_p->val, operation_first);
+            }
+            else if (validate_key(tmp_p->key, OPERATION_LAST, OPERATION_LAST_SIZE)) {
+                try_assign_subfield_bool(tmp_p->val, operation_last);
+            }
+            else {
+                *extra_subfields += 1;
             }
         }
     }
-    
+
     return op_status == OPERATION_EXISTED;
 }
 
-void pack_extra_operation_subfields(msgpack_packer *mp_pck, msgpack_object *operation, int extra_subfields) {
+void pack_extra_operation_subfields(msgpack_packer *mp_pck, 
+                                    msgpack_object *operation, int extra_subfields) {
     msgpack_object_kv *p = operation->via.map.ptr;
     msgpack_object_kv *const pend = operation->via.map.ptr + operation->via.map.size;
 
     msgpack_pack_map(mp_pck, extra_subfields);
 
     for (; p < pend; ++p) {
-        if (strncmp("id", p->key.via.str.ptr, p->key.via.str.size) != 0 
-            && strncmp("producer", p->key.via.str.ptr, p->key.via.str.size) != 0
-            && strncmp("first", p->key.via.str.ptr, p->key.via.str.size) != 0
-            && strncmp("last", p->key.via.str.ptr, p->key.via.str.size) != 0) {
-            msgpack_pack_object(mp_pck, p->key);
-            msgpack_pack_object(mp_pck, p->val);
+        if (validate_key(p->key, OPERATION_ID, OPERATION_ID_SIZE)
+            || validate_key(p->key, OPERATION_PRODUCER, OPERATION_PRODUCER_SIZE)
+            || validate_key(p->key, OPERATION_FIRST, OPERATION_FIRST_SIZE)
+            || validate_key(p->key, OPERATION_LAST, OPERATION_LAST_SIZE)) {
+            continue;
         }
-    }
 
+        msgpack_pack_object(mp_pck, p->key);
+        msgpack_pack_object(mp_pck, p->val);
+    }
 }

--- a/plugins/out_stackdriver/stackdriver_operation.h
+++ b/plugins/out_stackdriver/stackdriver_operation.h
@@ -22,15 +22,62 @@
 
 #include "stackdriver.h"
 
+/* subfield name and size */
+#define OPERATION_ID "id"
+#define OPERATION_PRODUCER "producer"
+#define OPERATION_FIRST "first"
+#define OPERATION_LAST "last"
+
+#define OPERATION_ID_SIZE 2
+#define OPERATION_PRODUCER_SIZE 8
+#define OPERATION_FIRST_SIZE 5
+#define OPERATION_LAST_SIZE 4
+
+/* 
+ *  Add operation field to the entries.
+ *  The structure of operation is:
+ *  {
+ *      "id": string,
+ *      "producer": string,
+ *      "first": boolean,
+ *      "last": boolean
+ *  }
+ * 
+ */                                                                                     
 void add_operation_field(flb_sds_t *operation_id, flb_sds_t *operation_producer, 
                          int *operation_first, int *operation_last, 
                          msgpack_packer *mp_pck);
 
+/*
+ *  Extract the operation field from the jsonPayload.
+ *  If the operation field exists, return TRUE and store the subfields.
+ *  If there are extra subfields, count the number.
+ */
 int extract_operation(flb_sds_t *operation_id, flb_sds_t *operation_producer, 
                       int *operation_first, int *operation_last, 
                       msgpack_object *obj, int *extra_subfields);
 
-void pack_extra_operation_subfields(msgpack_packer *mp_pck, msgpack_object *operation, int extra_subfields);
+/*
+ *  When there are extra subfields, we will preserve the extra subfields inside jsonPayload
+ *  For example, if the jsonPayload is as followed：
+ *  jsonPayload {
+ *      "logging.googleapis.com/operation": {
+ *          "id": "id1",
+ *          "producer": "id2",
+ *          "first": true,
+ *          "last": true,
+ *          "extra": "some string"  #extra subfield
+ *      }
+ *  }
+ *  We will preserve the extra subfields. The jsonPayload after extracting is:
+ *  jsonPayload {
+ *      "logging.googleapis.com/operation": {
+ *          "extra": "some string" 
+ *      }
+ *  }
+ */
+void pack_extra_operation_subfields(msgpack_packer *mp_pck, msgpack_object *operation, 
+                                    int extra_subfields);
 
 
 #endif

--- a/plugins/out_stackdriver/stackdriver_source_location.c
+++ b/plugins/out_stackdriver/stackdriver_source_location.c
@@ -1,0 +1,138 @@
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2020 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+#include "stackdriver.h"
+#include "stackdriver_helper.h"
+#include "stackdriver_source_location.h"
+
+typedef enum {
+    NO_SOURCELOCATION = 1,
+    SOURCELOCATION_EXISTED = 2
+} source_location_status;
+
+
+void add_source_location_field(flb_sds_t *source_location_file, 
+                               int64_t source_location_line, 
+                               flb_sds_t *source_location_function, 
+                               msgpack_packer *mp_pck)
+{    
+    msgpack_pack_str(mp_pck, 14);
+    msgpack_pack_str_body(mp_pck, "sourceLocation", 14);
+    msgpack_pack_map(mp_pck, 3);
+
+    msgpack_pack_str(mp_pck, SOURCE_LOCATION_FILE_SIZE);
+    msgpack_pack_str_body(mp_pck, SOURCE_LOCATION_FILE, SOURCE_LOCATION_FILE_SIZE);
+    msgpack_pack_str(mp_pck, flb_sds_len(*source_location_file));
+    msgpack_pack_str_body(mp_pck, *source_location_file, 
+                          flb_sds_len(*source_location_file));
+
+    msgpack_pack_str(mp_pck, SOURCE_LOCATION_LINE_SIZE);
+    msgpack_pack_str_body(mp_pck, SOURCE_LOCATION_LINE, SOURCE_LOCATION_LINE_SIZE);
+    msgpack_pack_int64(mp_pck, source_location_line);
+
+    msgpack_pack_str(mp_pck, SOURCE_LOCATION_FUNCTION_SIZE);
+    msgpack_pack_str_body(mp_pck, SOURCE_LOCATION_FUNCTION, 
+                          SOURCE_LOCATION_FUNCTION_SIZE);
+    msgpack_pack_str(mp_pck, flb_sds_len(*source_location_function));
+    msgpack_pack_str_body(mp_pck, *source_location_function, 
+                          flb_sds_len(*source_location_function));
+}
+
+/* Return FLB_TRUE if sourceLocation extracted */
+int extract_source_location(flb_sds_t *source_location_file, 
+                            int64_t *source_location_line,
+                            flb_sds_t *source_location_function, 
+                            msgpack_object *obj, int *extra_subfields)
+{
+    source_location_status op_status = NO_SOURCELOCATION;
+    msgpack_object_kv *p;
+    msgpack_object_kv *pend;
+    msgpack_object_kv *tmp_p;
+    msgpack_object_kv *tmp_pend;
+
+    if (obj->via.map.size == 0) {   
+        return FLB_FALSE;
+    } 	
+    p = obj->via.map.ptr;
+    pend = obj->via.map.ptr + obj->via.map.size;
+
+    for (; p < pend && op_status == NO_SOURCELOCATION; ++p) {
+
+        if (p->val.type != MSGPACK_OBJECT_MAP 
+            || p->key.type != MSGPACK_OBJECT_STR
+            || !validate_key(p->key, SOURCELOCATION_FIELD_IN_JSON, 
+                             SOURCE_LOCATION_SIZE)) {
+
+            continue;
+        }
+
+        op_status = SOURCELOCATION_EXISTED;
+        msgpack_object sub_field = p->val;
+
+        tmp_p = sub_field.via.map.ptr;
+        tmp_pend = sub_field.via.map.ptr + sub_field.via.map.size;
+
+        /* Validate the subfields of sourceLocation */
+        for (; tmp_p < tmp_pend; ++tmp_p) {
+            if (tmp_p->key.type != MSGPACK_OBJECT_STR) {
+                continue;
+            }
+
+            if (validate_key(tmp_p->key, 
+                             SOURCE_LOCATION_FILE, 
+                             SOURCE_LOCATION_FILE_SIZE)) {
+                try_assign_subfield_str(tmp_p->val, source_location_file);
+            }
+            else if (validate_key(tmp_p->key, 
+                                  SOURCE_LOCATION_FUNCTION, 
+                                  SOURCE_LOCATION_FUNCTION_SIZE)) {
+                try_assign_subfield_str(tmp_p->val, source_location_function);
+            }
+            else if (validate_key(tmp_p->key, 
+                                  SOURCE_LOCATION_LINE, 
+                                  SOURCE_LOCATION_LINE_SIZE)) {
+                try_assign_subfield_int(tmp_p->val, source_location_line);
+            }
+            else {
+                *extra_subfields += 1;
+            }
+        }
+    }
+
+    return op_status == SOURCELOCATION_EXISTED;
+}
+
+void pack_extra_source_location_subfields(msgpack_packer *mp_pck, 
+                                          msgpack_object *source_location, 
+                                          int extra_subfields) {
+    msgpack_object_kv *p = source_location->via.map.ptr;
+    msgpack_object_kv *const pend = source_location->via.map.ptr + source_location->via.map.size;
+
+    msgpack_pack_map(mp_pck, extra_subfields);
+
+    for (; p < pend; ++p) {
+        if (validate_key(p->key, SOURCE_LOCATION_FILE, SOURCE_LOCATION_FILE_SIZE)
+            || validate_key(p->key, SOURCE_LOCATION_LINE, SOURCE_LOCATION_LINE_SIZE)
+            || validate_key(p->key, SOURCE_LOCATION_FUNCTION, 
+                            SOURCE_LOCATION_FUNCTION_SIZE)) {
+            continue;
+        }
+
+        msgpack_pack_object(mp_pck, p->key);
+        msgpack_pack_object(mp_pck, p->val);
+    }
+}

--- a/plugins/out_stackdriver/stackdriver_source_location.h
+++ b/plugins/out_stackdriver/stackdriver_source_location.h
@@ -1,0 +1,81 @@
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2020 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+
+#ifndef FLB_STD_SOURCELOCATION_H
+#define FLB_STD_SOURCELOCATION_H
+
+#include "stackdriver.h"
+
+/* subfield name and size */
+#define SOURCE_LOCATION_FILE "file"
+#define SOURCE_LOCATION_LINE "line"
+#define SOURCE_LOCATION_FUNCTION "function"
+
+#define SOURCE_LOCATION_FILE_SIZE 4
+#define SOURCE_LOCATION_LINE_SIZE 4
+#define SOURCE_LOCATION_FUNCTION_SIZE 8
+
+/* 
+ *  Add sourceLocation field to the entries.
+ *  The structure of sourceLocation is:
+ *  {
+ *      "file": string,
+ *      "line": int,
+ *      "function": string
+ *  }
+ */   
+void add_source_location_field(flb_sds_t *source_location_file, 
+                               int64_t source_location_line,
+                               flb_sds_t *source_location_function, 
+                               msgpack_packer *mp_pck);
+
+/*
+ *  Extract the sourceLocation field from the jsonPayload.
+ *  If the sourceLocation field exists, return TRUE and store the subfields.
+ *  If there are extra subfields, count the number.
+ */
+int extract_source_location(flb_sds_t *source_location_file, 
+                            int64_t *source_location_line,
+                            flb_sds_t *source_location_function, 
+                            msgpack_object *obj, int *extra_subfields);
+
+/*
+ *  When there are extra subfields, we will preserve the extra subfields inside jsonPayload
+ *  For example, if the jsonPayload is as followed：
+ *  jsonPayload {
+ *      "logging.googleapis.com/sourceLocation": {
+ *          "file": "file1",
+ *          "line": 1,
+ *          "function": "func1",
+ *          "extra": "some string"  #extra subfield
+ *      }
+ *  }
+ *  We will preserve the extra subfields. The jsonPayload after extracting is:
+ *  jsonPayload {
+ *      "logging.googleapis.com/sourceLocation": {
+ *          "extra": "some string" 
+ *      }
+ *  }
+ */
+void pack_extra_source_location_subfields(msgpack_packer *mp_pck, 
+                                          msgpack_object *source_location, 
+                                          int extra_subfields);
+
+
+#endif

--- a/plugins/out_stackdriver/stackdriver_timestamp.c
+++ b/plugins/out_stackdriver/stackdriver_timestamp.c
@@ -1,0 +1,158 @@
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2020 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+#include "stackdriver.h"
+#include "stackdriver_helper.h"
+#include "stackdriver_timestamp.h"
+#include <fluent-bit/flb_regex.h>
+
+static int is_integer(char *str, int size) {
+    int i;
+    for (i = 0; i < size; ++ i) {
+        if (!isdigit(str[i])) {
+            return FLB_FALSE;
+        }
+    }
+    return FLB_TRUE;
+}
+
+static void try_assign_time(long long seconds, long long nanos, 
+                            struct flb_time *tms)
+{
+    if (seconds != 0) {
+        tms->tm.tv_sec = seconds;
+        tms->tm.tv_nsec = nanos;    
+    }
+}
+
+static long long get_integer(msgpack_object obj)
+{
+    if (obj.type == MSGPACK_OBJECT_POSITIVE_INTEGER) {
+        return obj.via.i64;
+    }
+    else if (obj.type == MSGPACK_OBJECT_STR 
+             && is_integer(obj.via.str.ptr, 
+                           obj.via.str.size)) {
+        return atoll(obj.via.str.ptr);
+    }
+    return 0;
+}
+
+static int extract_format_timestamp_object(msgpack_object *obj,
+                                           struct flb_time *tms)
+{
+    int seconds_found = FLB_FALSE;
+    int nanos_found = FLB_FALSE;
+    long long seconds = 0;
+    long long nanos = 0;
+
+    msgpack_object_kv *p;
+    msgpack_object_kv *pend;
+    msgpack_object_kv *tmp_p;
+    msgpack_object_kv *tmp_pend;
+
+    if (obj->via.map.size == 0) {    	
+        return FLB_FALSE;
+    }
+    p = obj->via.map.ptr;
+    pend = obj->via.map.ptr + obj->via.map.size;
+
+    for (; p < pend; ++p) {
+        if (!validate_key(p->key, "timestamp", 9) 
+            || p->val.type != MSGPACK_OBJECT_MAP) {
+            continue;
+        }
+
+        tmp_p = p->val.via.map.ptr;
+        tmp_pend = p->val.via.map.ptr + p->val.via.map.size;
+
+        for (; tmp_p < tmp_pend; ++tmp_p) {
+            if (validate_key(tmp_p->key, "seconds", 7)) {
+                seconds_found = FLB_TRUE;
+                seconds = get_integer(tmp_p->val);
+                
+                if (nanos_found == FLB_TRUE) {
+                    try_assign_time(seconds, nanos, tms);
+                    return FLB_TRUE;
+                }
+            }
+            else if (validate_key(tmp_p->key, "nanos", 5)) {
+                nanos_found = FLB_TRUE;
+                nanos = get_integer(tmp_p->val);
+
+                if (seconds_found == FLB_TRUE) {
+                    try_assign_time(seconds, nanos, tms);
+                    return FLB_TRUE;
+                }
+            }
+        }
+    }
+    return FLB_FALSE;
+}
+
+static int extract_format_timestamp_duo_fields(msgpack_object *obj,
+                                               struct flb_time *tms)
+{
+    int seconds_found = FLB_FALSE;
+    int nanos_found = FLB_FALSE;
+    long long seconds = 0;
+    long long nanos = 0;
+
+    msgpack_object_kv *p;
+    msgpack_object_kv *pend;
+
+    if (obj->via.map.size == 0) {    	
+        return FLB_FALSE;
+    }
+    p = obj->via.map.ptr;
+    pend = obj->via.map.ptr + obj->via.map.size;
+
+    for (; p < pend; ++p) {
+        if (validate_key(p->key, "timestampSeconds", 16)) {
+            seconds_found = FLB_TRUE;
+            seconds = get_integer(p->val);
+
+            if (nanos_found == FLB_TRUE) {
+                try_assign_time(seconds, nanos, tms);
+                return FLB_TRUE;
+            }
+        }
+        else if (validate_key(p->key, "timestampNanos", 14)) {
+            nanos_found = FLB_TRUE;
+            nanos = get_integer(p->val);
+
+            if (seconds_found == FLB_TRUE) {
+                try_assign_time(seconds, nanos, tms);
+                return FLB_TRUE;
+            }
+        } 
+    }
+
+    return FLB_FALSE;
+}
+
+timestamp_status extract_timestamp(msgpack_object *obj,
+                                   struct flb_time *tms)
+{
+    if (extract_format_timestamp_object(obj, tms)) {
+        return FORMAT_TIMESTAMP_OBJECT;
+    }
+    if (extract_format_timestamp_duo_fields(obj, tms)) {
+        return FORMAT_TIMESTAMP_DUO_FIELDS;
+    }
+    return TIMESTAMP_NOT_PRESENT;
+}

--- a/plugins/out_stackdriver/stackdriver_timestamp.h
+++ b/plugins/out_stackdriver/stackdriver_timestamp.h
@@ -1,0 +1,48 @@
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2020 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+
+#ifndef FLB_STD_TIMESTAMP_H
+#define FLB_STD_TIEMSTAMP_H
+
+#include "stackdriver.h"
+#include <fluent-bit/flb_time.h>
+
+typedef enum {
+    TIMESTAMP_NOT_PRESENT = 0,
+    FORMAT_TIMESTAMP_OBJECT = 1,
+    FORMAT_TIMESTAMP_DUO_FIELDS = 2
+} timestamp_status;
+
+/* 
+ * Currently support two formats of time-related fields
+ *      - "timestamp":{"seconds", "nanos"}
+ *      - "timestampSeconds"/"timestampNanos"
+ * 
+ * If timestamp field is not existed, return TIMESTAMP_NOT_PRESENT 
+ * If timestamp format is "timestamp":{"seconds", "nanos"}, 
+ * set the time and return FORMAT_TIMESTAMP
+ * 
+ * If timestamp format is "timestampSeconds"/"timestampNanos", 
+ * set the time and return FORMAT_TIMESTAMPSECONDS
+ */
+timestamp_status extract_timestamp(msgpack_object *obj,
+                                   struct flb_time *tms);
+
+
+#endif

--- a/tests/runtime/data/stackdriver/stackdriver_multi_entries_severity.log
+++ b/tests/runtime/data/stackdriver/stackdriver_multi_entries_severity.log
@@ -1,3 +1,4 @@
 {"message":"test severity1", "severity":"INFO"}
 {"message":"test severity2"}
-{"message":"test severity3", "severity":"INFO"}
+{"message":"test severity3", "severity":"DEBUG"}
+{"message":"test severity4"}

--- a/tests/runtime/data/stackdriver/stackdriver_test_http_request.h
+++ b/tests/runtime/data/stackdriver/stackdriver_test_http_request.h
@@ -1,0 +1,134 @@
+#define HTTPREQUEST_COMMON_CASE	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/http_request\": "		\
+        "{"            \
+            "\"requestMethod\": \"test_requestMethod\","          \
+            "\"requestUrl\": \"test_requestUrl\","      \
+            "\"userAgent\": \"test_userAgent\","      \
+            "\"remoteIp\": \"test_remoteIp\","          \
+            "\"serverIp\": \"test_serverIp\","      \
+            "\"referer\": \"test_referer\","          \
+            "\"latency\": \"0s\","      \
+            "\"protocol\": \"test_protocol\","      \
+            "\"requestSize\": 123,"          \
+            "\"responseSize\": 123,"      \
+            "\"status\": 200,"      \
+            "\"cacheFillBytes\": 123,"          \
+            "\"cacheLookup\": true,"      \
+            "\"cacheHit\": true,"      \
+            "\"cacheValidatedWithOriginServer\": true"      \
+        "}"     \
+	"}]"
+
+#define EMPTY_HTTPREQUEST	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/http_request\": "		\
+        "{"            \
+        "}"     \
+	"}]"
+
+#define HTTPREQUEST_IN_STRING "["		\
+	"1591111124,"			\
+	"{"				\
+    "\"logging.googleapis.com/http_request\": \"some string\""		\
+	"}]"
+
+#define PARTIAL_HTTPREQUEST	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/http_request\": "		\
+        "{"            \
+            "\"cacheLookup\": true,"      \
+            "\"cacheHit\": true,"      \
+            "\"cacheValidatedWithOriginServer\": true"      \
+        "}"     \
+	"}]"
+
+#define HTTPREQUEST_SUBFIELDS_IN_INCORRECT_TYPE	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/http_request\": "		\
+        "{"            \
+            "\"requestMethod\": 123,"          \
+            "\"requestUrl\": 123,"      \
+            "\"userAgent\": 123,"      \
+            "\"remoteIp\": 123,"          \
+            "\"serverIp\": true,"      \
+            "\"referer\": true,"          \
+            "\"latency\": false,"      \
+            "\"protocol\": false,"      \
+            "\"requestSize\": \"some string\","          \
+            "\"responseSize\": true,"      \
+            "\"status\": false,"      \
+            "\"cacheFillBytes\": false,"          \
+            "\"cacheLookup\": \"some string\","      \
+            "\"cacheHit\": 123,"      \
+            "\"cacheValidatedWithOriginServer\": 123"      \
+        "}"     \
+	"}]"
+
+#define HTTPREQUEST_EXTRA_SUBFIELDS_EXISTED	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/http_request\": "		\
+        "{"            \
+            "\"requestMethod\": \"test_requestMethod\","          \
+            "\"requestUrl\": \"test_requestUrl\","      \
+            "\"userAgent\": \"test_userAgent\","      \
+            "\"remoteIp\": \"test_remoteIp\","          \
+            "\"serverIp\": \"test_serverIp\","      \
+            "\"referer\": \"test_referer\","          \
+            "\"latency\": \"0s\","      \
+            "\"protocol\": \"test_protocol\","      \
+            "\"requestSize\": 123,"          \
+            "\"responseSize\": 123,"      \
+            "\"status\": 200,"      \
+            "\"cacheFillBytes\": 123,"          \
+            "\"cacheLookup\": true,"      \
+            "\"cacheHit\": true,"      \
+            "\"cacheValidatedWithOriginServer\": true,"      \
+            "\"extra_key1\": \"extra_val1\","          \
+            "\"extra_key2\": 123,"      \
+            "\"extra_key3\": true"          \
+        "}"     \
+	"}]"
+
+
+/* Tests for 'latency' */
+#define HTTPREQUEST_LATENCY_COMMON_CASE	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/http_request\": "		\
+        "{"            \
+            "\"latency\": \"  100.00  s  \""      \
+        "}"     \
+	"}]"
+
+#define HTTPREQUEST_LATENCY_INVALID_SPACES	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/http_request\": "		\
+        "{"            \
+            "\"latency\": \"  100. 00  s  \""      \
+        "}"     \
+	"}]"
+
+#define HTTPREQUEST_LATENCY_INVALID_STRING	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/http_request\": "		\
+        "{"            \
+            "\"latency\": \"  s100.00  s  \""      \
+        "}"     \
+	"}]"
+
+#define HTTPREQUEST_LATENCY_INVALID_END	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/http_request\": "		\
+        "{"            \
+            "\"latency\": \"  100.00    \""      \
+        "}"     \
+	"}]"

--- a/tests/runtime/data/stackdriver/stackdriver_test_insert_id.h
+++ b/tests/runtime/data/stackdriver/stackdriver_test_insert_id.h
@@ -1,0 +1,27 @@
+
+#define INSERTID_COMMON_CASE	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/insertId\": \"test_insertId\" "		\
+	"}]"
+
+#define EMPTY_INSERTID	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/insertId\": \"\" "		\
+	"}]"
+
+#define INSERTID_INCORRECT_TYPE_INT	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/insertId\": 123 "		\
+	"}]"
+
+#define INSERTID_INCORRECT_TYPE_MAP	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/insertId\": "		\
+        "{"           \       
+        "}"     \
+	"}]"	
+	

--- a/tests/runtime/data/stackdriver/stackdriver_test_source_location.h
+++ b/tests/runtime/data/stackdriver/stackdriver_test_source_location.h
@@ -1,0 +1,70 @@
+#define SOURCELOCATION_COMMON_CASE	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/sourceLocation\": "		\
+        "{"            \
+            "\"file\": \"test_file\","          \
+            "\"line\": 123,"      \
+            "\"function\": \"test_function\""      \
+        "}"     \
+	"}]"
+
+#define SOURCELOCATION_COMMON_CASE_LINE_IN_STRING	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/sourceLocation\": "		\
+        "{"            \
+            "\"file\": \"test_file\","          \
+            "\"line\": \"123\","      \
+            "\"function\": \"test_function\""      \
+        "}"     \
+	"}]"
+
+#define EMPTY_SOURCELOCATION	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/sourceLocation\": "		\
+        "{"            \
+        "}"     \
+	"}]"
+
+#define SOURCELOCATION_IN_STRING "["		\
+	"1591111124,"			\
+	"{"				\
+    "\"logging.googleapis.com/sourceLocation\": \"some string\""		\
+	"}]"
+
+#define PARTIAL_SOURCELOCATION	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/sourceLocation\": "		\
+        "{"            \
+            "\"function\": \"test_function\""   \
+        "}"     \
+	"}]"
+
+#define SOURCELOCATION_SUBFIELDS_IN_INCORRECT_TYPE	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/sourceLocation\": "		\
+        "{"            \
+            "\"file\": 123,"          \
+            "\"line\": \"some string\","      \
+            "\"function\": true"      \
+        "}"     \
+	"}]"
+
+#define SOURCELOCATION_EXTRA_SUBFIELDS_EXISTED	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"logging.googleapis.com/sourceLocation\": "		\
+        "{"            \
+            "\"file\": \"test_file\","          \
+            "\"line\": 123,"      \
+            "\"function\": \"test_function\","      \
+            "\"extra_key1\": \"extra_val1\","          \
+            "\"extra_key2\": 123,"      \
+            "\"extra_key3\": true"          \
+        "}"     \
+	"}]"
+    

--- a/tests/runtime/data/stackdriver/stackdriver_test_timestamp.h
+++ b/tests/runtime/data/stackdriver/stackdriver_test_timestamp.h
@@ -1,0 +1,62 @@
+/* timestamp after parsing: 2020-07-21T16:40:42.000012345Z */
+#define TIMESTAMP_FORMAT_OBJECT_COMMON_CASE	"["		\
+	"1591111124,"			\
+	"{"				\
+        "\"timestamp\": "		\
+        "{"            \
+            "\"seconds\": \"1595349642\","          \
+            "\"nanos\": \"12345\""      \
+        "}"     \
+	"}]"
+
+/* "1595349600" in RFC3339 format: 2020-07-21T16:40:00Z */
+#define TIMESTAMP_FORMAT_OBJECT_NOT_A_MAP	"["		\
+	"1595349600,"			\
+	"{"				\
+        "\"timestamp\": \"string\""	     \
+	"}]"
+
+/* "1595349600" in RFC3339 format: 2020-07-21T16:40:00Z */
+#define TIMESTAMP_FORMAT_OBJECT_MISSING_SUBFIELD	"["		\
+	"1595349600,"			\
+	"{"				\
+        "\"timestamp\": "		\
+        "{"            \
+            "\"nanos\": \"12345\""      \
+        "}"     \
+	"}]"
+
+/* "1595349600" in RFC3339 format: 2020-07-21T16:40:00Z */
+#define TIMESTAMP_FORMAT_OBJECT_INCORRECT_TYPE_SUBFIELDS	"["		\
+	"1595349600,"			\
+	"{"				\
+        "\"timestamp\": "		\
+        "{"            \
+            "\"seconds\": \"string\","          \
+            "\"nanos\": true"      \
+        "}"     \
+	"}]"
+
+
+/* timestamp after parsing: 2020-07-21T16:40:42.000012345Z */
+#define TIMESTAMP_FORMAT_DUO_FIELDS_COMMON_CASE	"["		\
+	"1595349600,"			\
+	"{"				\
+        "\"timestampSeconds\": \"1595349642\","	     \
+        "\"timestampNanos\": \"12345\""	     \
+	"}]"
+
+/* "1595349600" in RFC3339 format: 2020-07-21T16:40:00Z */
+#define TIMESTAMP_FORMAT_DUO_FIELDS_MISSING_NANOS	"["		\
+	"1595349600,"			\
+	"{"				\
+        "\"timestampSeconds\": \"1595349642\""	     \
+	"}]"
+
+/* "1595349600" in RFC3339 format: 2020-07-21T16:40:00Z */
+#define TIMESTAMP_FORMAT_DUO_FIELDS_INCORRECT_TYPE	"["		\
+	"1595349600,"			\
+	"{"				\
+        "\"timestampSeconds\": \"string\","	     \
+        "\"timestampNanos\": true"	     \
+	"}]"

--- a/tests/runtime/out_stackdriver.c
+++ b/tests/runtime/out_stackdriver.c
@@ -35,6 +35,7 @@
 #include "data/stackdriver/stackdriver_test_k8s_resource.h"
 #include "data/stackdriver/stackdriver_test_labels.h"
 #include "data/stackdriver/stackdriver_test_insert_id.h"
+#include "data/stackdriver/stackdriver_test_source_location.h"
 
 /*
  * Fluent Bit Stackdriver plugin, always set as payload a JSON strings contained in a
@@ -855,6 +856,180 @@ static void cb_check_multi_entries_severity(void *ctx, int ffd,
     flb_sds_destroy(res_data);
 }
 
+static void cb_check_source_location_common_case(void *ctx, int ffd,
+                                                 int res_ret, void *res_data, size_t res_size,
+                                                 void *data)
+{
+    int ret;
+
+    /* sourceLocation_file */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['sourceLocation']['file']", "test_file");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* sourceLocation_line */
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['sourceLocation']['line']", 123);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* sourceLocation_function */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['sourceLocation']['function']", "test_function");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* check `sourceLocation` has been removed from jsonPayload */
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/sourceLocation']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_source_location_common_case_line_in_string(void *ctx, int ffd,
+                                                                int res_ret, void *res_data, size_t res_size,
+                                                                void *data)
+{
+    int ret;
+
+    /* sourceLocation_file */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['sourceLocation']['file']", "test_file");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* sourceLocation_line */
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['sourceLocation']['line']", 123);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* sourceLocation_function */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['sourceLocation']['function']", "test_function");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* check `sourceLocation` has been removed from jsonPayload */
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/sourceLocation']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_empty_source_location(void *ctx, int ffd,
+                                           int res_ret, void *res_data, size_t res_size,
+                                           void *data)
+{
+    int ret;
+
+    /* sourceLocation_file */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['sourceLocation']['file']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* sourceLocation_line */
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['sourceLocation']['line']", 0);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* sourceLocation_function */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['sourceLocation']['function']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* check `sourceLocation` has been removed from jsonPayload */
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/sourceLocation']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_source_location_in_string(void *ctx, int ffd,
+                                               int res_ret, void *res_data, size_t res_size,
+                                               void *data)
+{
+    int ret;
+
+    /* sourceLocation remains in jsonPayload */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/sourceLocation']", "some string");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['sourceLocation']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_source_location_partial_subfields(void *ctx, int ffd,
+                                                       int res_ret, void *res_data, size_t res_size,
+                                                       void *data)
+{
+    int ret;
+
+    /* sourceLocation_file */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['sourceLocation']['file']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* sourceLocation_line */
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['sourceLocation']['line']", 0);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* sourceLocation_function */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['sourceLocation']['function']", "test_function");
+    TEST_CHECK(ret == FLB_TRUE);
+
+
+    /* check `sourceLocation` has been removed from jsonPayload */
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/sourceLocation']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_source_location_incorrect_type_subfields(void *ctx, int ffd,
+                                                              int res_ret, void *res_data, size_t res_size,
+                                                              void *data)
+{
+    int ret;
+
+    /* sourceLocation_file */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['sourceLocation']['file']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* sourceLocation_line */
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['sourceLocation']['line']", 0);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* sourceLocation_function */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['sourceLocation']['function']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+
+    /* check `sourceLocation` has been removed from jsonPayload */
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/sourceLocation']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_source_location_extra_subfields(void *ctx, int ffd,
+                                                     int res_ret, void *res_data, size_t res_size,
+                                                     void *data)
+{
+    int ret;
+
+    /* sourceLocation_file */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['sourceLocation']['file']", "test_file");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* sourceLocation_line */
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['sourceLocation']['line']", 123);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* sourceLocation_function */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['sourceLocation']['function']", "test_function");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* Preserve extra subfields inside jsonPayload */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/sourceLocation']['extra_key1']", "extra_val1");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/sourceLocation']['extra_key2']", 123);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/sourceLocation']['extra_key3']", true);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    flb_sds_destroy(res_data);
+}
+
 void flb_test_resource_global()
 {
     int ret;
@@ -1639,6 +1814,286 @@ void flb_test_multi_entries_severity()
     flb_destroy(ctx);
 }
 
+void flb_test_source_location_common_case()
+{
+    int ret;
+    int size = sizeof(SOURCELOCATION_COMMON_CASE) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_source_location_common_case,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) SOURCELOCATION_COMMON_CASE, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_source_location_line_in_string()
+{
+    int ret;
+    int size = sizeof(SOURCELOCATION_COMMON_CASE_LINE_IN_STRING) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_source_location_common_case_line_in_string,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) SOURCELOCATION_COMMON_CASE_LINE_IN_STRING, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_empty_source_location()
+{
+    int ret;
+    int size = sizeof(EMPTY_SOURCELOCATION) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_empty_source_location,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) EMPTY_SOURCELOCATION, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_source_location_in_string()
+{
+    int ret;
+    int size = sizeof(SOURCELOCATION_IN_STRING) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_source_location_in_string,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) SOURCELOCATION_IN_STRING, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_source_location_partial_subfields()
+{
+    int ret;
+    int size = sizeof(PARTIAL_SOURCELOCATION) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_source_location_partial_subfields,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) PARTIAL_SOURCELOCATION, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_source_location_incorrect_type_subfields()
+{
+    int ret;
+    int size = sizeof(SOURCELOCATION_SUBFIELDS_IN_INCORRECT_TYPE) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_source_location_incorrect_type_subfields,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) SOURCELOCATION_SUBFIELDS_IN_INCORRECT_TYPE, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_source_location_extra_subfields()
+{
+    int ret;
+    int size = sizeof(SOURCELOCATION_EXTRA_SUBFIELDS_EXISTED) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_source_location_extra_subfields,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) SOURCELOCATION_EXTRA_SUBFIELDS_EXISTED, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
 /* Test list */
 TEST_LIST = {
     {"severity_multi_entries", flb_test_multi_entries_severity },
@@ -1657,6 +2112,15 @@ TEST_LIST = {
     {"operation_partial_subfields", flb_test_operation_partial_subfields},
     {"operation_subfields_in_incorrect_type", flb_test_operation_incorrect_type_subfields},
     {"operation_extra_subfields_exist", flb_test_operation_extra_subfields},
+
+    /* test sourceLocation */
+    {"sourceLocation_common_case", flb_test_source_location_common_case},
+    {"sourceLocation_line_in_string", flb_test_source_location_line_in_string},
+    {"empty_sourceLocation", flb_test_empty_source_location},
+    {"sourceLocation_not_a_map", flb_test_source_location_in_string},
+    {"sourceLocation_partial_subfields", flb_test_source_location_partial_subfields},
+    {"sourceLocation_subfields_in_incorrect_type", flb_test_source_location_incorrect_type_subfields},
+    {"sourceLocation_extra_subfields_exist", flb_test_source_location_extra_subfields},
 
     /* test k8s */
     {"resource_k8s_container_common", flb_test_resource_k8s_container_common },

--- a/tests/runtime/out_stackdriver.c
+++ b/tests/runtime/out_stackdriver.c
@@ -807,11 +807,14 @@ static void cb_check_multi_entries_severity(void *ctx, int ffd,
     ret = mp_kv_cmp(res_data, res_size, "$entries[0]['severity']", "INFO");
     TEST_CHECK(ret == FLB_TRUE);
 
-    ret = mp_kv_cmp(res_data, res_size, "$entries[1]['severity']", "INFO");
+    ret = mp_kv_exists(res_data, res_size, "$entries[1]['severity']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[2]['severity']", "DEBUG");
     TEST_CHECK(ret == FLB_TRUE);
 
-    ret = mp_kv_cmp(res_data, res_size, "$entries[2]['severity']", "INFO");
-    TEST_CHECK(ret == FLB_TRUE);
+    ret = mp_kv_exists(res_data, res_size, "$entries[3]['severity']");
+    TEST_CHECK(ret == FLB_FALSE);
 
     flb_sds_destroy(res_data);
 }

--- a/tests/runtime/out_stackdriver.c
+++ b/tests/runtime/out_stackdriver.c
@@ -36,6 +36,7 @@
 #include "data/stackdriver/stackdriver_test_labels.h"
 #include "data/stackdriver/stackdriver_test_insert_id.h"
 #include "data/stackdriver/stackdriver_test_source_location.h"
+#include "data/stackdriver/stackdriver_test_http_request.h"
 
 /*
  * Fluent Bit Stackdriver plugin, always set as payload a JSON strings contained in a
@@ -1030,6 +1031,348 @@ static void cb_check_source_location_extra_subfields(void *ctx, int ffd,
     flb_sds_destroy(res_data);
 }
 
+static void cb_check_http_request_common_case(void *ctx, int ffd,
+                                             int res_ret, void *res_data, size_t res_size,
+                                             void *data)
+{
+    int ret;
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['requestMethod']", "test_requestMethod");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['requestUrl']", "test_requestUrl");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['userAgent']", "test_userAgent");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['remoteIp']", "test_remoteIp");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['serverIp']", "test_serverIp");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['referer']", "test_referer");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['protocol']", "test_protocol");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['latency']", "0s");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['httpRequest']['requestSize']", 123);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['httpRequest']['responseSize']", 123);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['httpRequest']['status']", 200);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['httpRequest']['cacheFillBytes']", 123);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['httpRequest']['cacheLookup']", true);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['httpRequest']['cacheHit']", true);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['httpRequest']['cacheValidatedWithOriginServer']", true);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* check `httpRequest` has been removed from jsonPayload */
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/http_request']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_empty_http_request(void *ctx, int ffd,
+                                        int res_ret, void *res_data, size_t res_size,
+                                        void *data)
+{
+    int ret;
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['requestMethod']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['requestUrl']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['userAgent']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['remoteIp']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['serverIp']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['referer']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['protocol']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_exists(res_data, res_size,  "$entries[0]['httpRequest']['latency']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['httpRequest']['requestSize']", 0);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['httpRequest']['responseSize']", 0);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['httpRequest']['status']", 0);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['httpRequest']['cacheFillBytes']", 0);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['httpRequest']['cacheLookup']", false);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['httpRequest']['cacheHit']", false);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['httpRequest']['cacheValidatedWithOriginServer']", false);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* check `httpRequest` has been removed from jsonPayload */
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/http_request']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_http_request_in_string(void *ctx, int ffd,
+                                            int res_ret, void *res_data, size_t res_size,
+                                            void *data)
+{
+    int ret;
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/http_request']", "some string");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['httpRequest']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_http_request_partial_subfields(void *ctx, int ffd,
+                                                    int res_ret, void *res_data, size_t res_size,
+                                                    void *data)
+{
+    int ret;
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['requestMethod']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['requestUrl']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['userAgent']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['remoteIp']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['serverIp']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['referer']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['protocol']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_exists(res_data, res_size,  "$entries[0]['httpRequest']['latency']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['httpRequest']['requestSize']", 0);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['httpRequest']['responseSize']", 0);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['httpRequest']['status']", 0);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['httpRequest']['cacheFillBytes']", 0);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['httpRequest']['cacheLookup']", true);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['httpRequest']['cacheHit']", true);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['httpRequest']['cacheValidatedWithOriginServer']", true);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* check `httpRequest` has been removed from jsonPayload */
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/http_request']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_http_request_incorrect_type_subfields(void *ctx, int ffd,
+                                                           int res_ret, void *res_data, size_t res_size,
+                                                           void *data)
+{
+    int ret;
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['requestMethod']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['requestUrl']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['userAgent']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['remoteIp']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['serverIp']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['referer']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['protocol']", "");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_exists(res_data, res_size,  "$entries[0]['httpRequest']['latency']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['httpRequest']['requestSize']", 0);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['httpRequest']['responseSize']", 0);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['httpRequest']['status']", 0);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['httpRequest']['cacheFillBytes']", 0);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['httpRequest']['cacheLookup']", false);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['httpRequest']['cacheHit']", false);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['httpRequest']['cacheValidatedWithOriginServer']", false);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* check `httpRequest` has been removed from jsonPayload */
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/http_request']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_http_request_extra_subfields(void *ctx, int ffd,
+                                                  int res_ret, void *res_data, size_t res_size,
+                                                  void *data)
+{
+     int ret;
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['requestMethod']", "test_requestMethod");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['requestUrl']", "test_requestUrl");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['userAgent']", "test_userAgent");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['remoteIp']", "test_remoteIp");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['serverIp']", "test_serverIp");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['referer']", "test_referer");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['protocol']", "test_protocol");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['latency']", "0s");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['httpRequest']['requestSize']", 123);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['httpRequest']['responseSize']", 123);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['httpRequest']['status']", 200);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['httpRequest']['cacheFillBytes']", 123);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['httpRequest']['cacheLookup']", true);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['httpRequest']['cacheHit']", true);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['httpRequest']['cacheValidatedWithOriginServer']", true);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* Preserve extra subfields inside jsonPayload */
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/http_request']['extra_key1']", "extra_val1");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_integer(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/http_request']['extra_key2']", 123);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    ret = mp_kv_cmp_boolean(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/http_request']['extra_key3']", true);
+    TEST_CHECK(ret == FLB_TRUE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_http_request_lantency_common_case(void *ctx, int ffd,
+                                                       int res_ret, void *res_data, size_t res_size,
+                                                       void *data)
+{
+    int ret;
+
+    ret = mp_kv_cmp(res_data, res_size, "$entries[0]['httpRequest']['latency']", "100.00s");
+    TEST_CHECK(ret == FLB_TRUE);
+
+    /* check `httpRequest` has been removed from jsonPayload */
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/http_request']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
+}
+
+static void cb_check_http_request_latency_incorrect_format(void *ctx, int ffd,
+                                                           int res_ret, void *res_data, size_t res_size,
+                                                           void *data)
+{
+    int ret;
+
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['httpRequest']['latency']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    /* check `httpRequest` has been removed from jsonPayload */
+    ret = mp_kv_exists(res_data, res_size, "$entries[0]['jsonPayload']['logging.googleapis.com/http_request']");
+    TEST_CHECK(ret == FLB_FALSE);
+
+    flb_sds_destroy(res_data);
+}
 
 void flb_test_resource_global()
 {
@@ -2095,6 +2438,406 @@ void flb_test_source_location_extra_subfields()
     flb_destroy(ctx);
 }
 
+void flb_test_http_request_common_case()
+{
+    int ret;
+    int size = sizeof(HTTPREQUEST_COMMON_CASE) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_http_request_common_case,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) HTTPREQUEST_COMMON_CASE, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_empty_http_request()
+{
+    int ret;
+    int size = sizeof(EMPTY_HTTPREQUEST) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_empty_http_request,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) EMPTY_HTTPREQUEST, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_http_request_in_string()
+{
+    int ret;
+    int size = sizeof(HTTPREQUEST_IN_STRING) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_http_request_in_string,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) HTTPREQUEST_IN_STRING, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_http_request_partial_subfields()
+{
+    int ret;
+    int size = sizeof(PARTIAL_HTTPREQUEST) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_http_request_partial_subfields,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) PARTIAL_HTTPREQUEST, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_http_request_incorrect_type_subfields()
+{
+    int ret;
+    int size = sizeof(HTTPREQUEST_SUBFIELDS_IN_INCORRECT_TYPE) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_http_request_incorrect_type_subfields,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) HTTPREQUEST_SUBFIELDS_IN_INCORRECT_TYPE, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_http_request_extra_subfields()
+{
+    int ret;
+    int size = sizeof(HTTPREQUEST_EXTRA_SUBFIELDS_EXISTED) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_http_request_extra_subfields,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) HTTPREQUEST_EXTRA_SUBFIELDS_EXISTED, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_http_request_latency_common_case()
+{
+    int ret;
+    int size = sizeof(HTTPREQUEST_LATENCY_COMMON_CASE) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_http_request_lantency_common_case,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) HTTPREQUEST_LATENCY_COMMON_CASE, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_http_request_latency_invalid_spaces()
+{
+    int ret;
+    int size = sizeof(HTTPREQUEST_LATENCY_INVALID_SPACES) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_http_request_latency_incorrect_format,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) HTTPREQUEST_LATENCY_INVALID_SPACES, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_http_request_latency_invalid_string()
+{
+    int ret;
+    int size = sizeof(HTTPREQUEST_LATENCY_INVALID_STRING) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_http_request_latency_incorrect_format,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) HTTPREQUEST_LATENCY_INVALID_STRING, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_http_request_latency_invalid_end()
+{
+    int ret;
+    int size = sizeof(HTTPREQUEST_LATENCY_INVALID_END) - 1;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* Create context, flush every second (some checks omitted here) */
+    ctx = flb_create();
+    flb_service_set(ctx, "flush", "1", "grace", "1", NULL);
+
+    /* Lib input mode */
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    flb_input_set(ctx, in_ffd, "tag", "test", NULL);
+
+    /* Stackdriver output */
+    out_ffd = flb_output(ctx, (char *) "stackdriver", NULL);
+    flb_output_set(ctx, out_ffd,
+                   "match", "test",
+                   "resource", "gce_instance",
+                   NULL);
+
+    /* Enable test mode */
+    ret = flb_output_set_test(ctx, out_ffd, "formatter",
+                              cb_check_http_request_latency_incorrect_format,
+                              NULL, NULL);
+
+    /* Start */
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    /* Ingest data sample */
+    flb_lib_push(ctx, in_ffd, (char *) HTTPREQUEST_LATENCY_INVALID_END, size);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
 /* Test list */
 TEST_LIST = {
     {"severity_multi_entries", flb_test_multi_entries_severity },
@@ -2131,6 +2874,18 @@ TEST_LIST = {
     {"custom_labels", flb_test_custom_labels },
     {"default_labels_k8s_resource_type", flb_test_default_labels_k8s_resource_type },
     {"custom_labels_k8s_resource_type", flb_test_custom_labels_k8s_resource_type },
+
+    /* test httpRequest */
+    {"httpRequest_common_case", flb_test_http_request_common_case},
+    {"empty_httpRequest", flb_test_empty_http_request},
+    {"httpRequest_not_a_map", flb_test_http_request_in_string},
+    {"httpRequest_partial_subfields", flb_test_http_request_partial_subfields},
+    {"httpRequest_subfields_in_incorret_type", flb_test_http_request_incorrect_type_subfields},
+    {"httpRequest_extra_subfields_exist", flb_test_http_request_extra_subfields},
+    {"httpRequest_common_latency", flb_test_http_request_latency_common_case},
+    {"httpRequest_latency_incorrect_spaces", flb_test_http_request_latency_invalid_spaces},
+    {"httpRequest_latency_incorrect_string", flb_test_http_request_latency_invalid_string},
+    {"httpRequest_latency_incorrect_end", flb_test_http_request_latency_invalid_end},
 
     {NULL, NULL}
 };

--- a/tests/runtime/out_stackdriver.c
+++ b/tests/runtime/out_stackdriver.c
@@ -1030,6 +1030,7 @@ static void cb_check_source_location_extra_subfields(void *ctx, int ffd,
     flb_sds_destroy(res_data);
 }
 
+
 void flb_test_resource_global()
 {
     int ret;
@@ -2121,7 +2122,7 @@ TEST_LIST = {
     {"sourceLocation_partial_subfields", flb_test_source_location_partial_subfields},
     {"sourceLocation_subfields_in_incorrect_type", flb_test_source_location_incorrect_type_subfields},
     {"sourceLocation_extra_subfields_exist", flb_test_source_location_extra_subfields},
-
+    
     /* test k8s */
     {"resource_k8s_container_common", flb_test_resource_k8s_container_common },
     {"resource_k8s_node_common", flb_test_resource_k8s_node_common },

--- a/tests/runtime/out_stackdriver.c
+++ b/tests/runtime/out_stackdriver.c
@@ -1127,6 +1127,7 @@ void flb_test_operation_extra_subfields()
     ret = flb_output_set_test(ctx, out_ffd, "formatter",
                               cb_check_operation_extra_subfields,
                               NULL, NULL);
+
     /* Start */
     ret = flb_start(ctx);
     TEST_CHECK(ret == 0);
@@ -1487,12 +1488,16 @@ TEST_LIST = {
     {"severity_multi_entries", flb_test_multi_entries_severity },
     {"resource_global", flb_test_resource_global },
     {"resource_gce_instance", flb_test_resource_gce_instance },
+
+    /* test operation */
     {"operation_common_case", flb_test_operation_common},
     {"empty_operation", flb_test_empty_operation},
     {"operation_not_a_map", flb_test_operation_in_string},
     {"operation_partial_subfields", flb_test_operation_partial_subfields},
     {"operation_subfields_in_incorrect_type", flb_test_operation_incorrect_type_subfields},
     {"operation_extra_subfields_exist", flb_test_operation_extra_subfields},
+
+    /* test k8s */
     {"resource_k8s_container_common", flb_test_resource_k8s_container_common },
     {"resource_k8s_node_common", flb_test_resource_k8s_node_common },
     {"resource_k8s_pod_common", flb_test_resource_k8s_pod_common },
@@ -1500,5 +1505,6 @@ TEST_LIST = {
     {"custom_labels", flb_test_custom_labels },
     {"default_labels_k8s_resource_type", flb_test_default_labels_k8s_resource_type },
     {"custom_labels_k8s_resource_type", flb_test_custom_labels_k8s_resource_type },
+
     {NULL, NULL}
 };


### PR DESCRIPTION
Support time-related fields - `timestamp` and `timestampSeconds/timestampNanos`

Commit 1 is for `timestamp`.
Commit 2 is for `timestampSeconds/timestampNanos`
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
